### PR TITLE
Add GitHub Action to publish songs JSON

### DIFF
--- a/.github/workflows/generate_and_upload.yml
+++ b/.github/workflows/generate_and_upload.yml
@@ -1,0 +1,30 @@
+name: Generate Songs JSON and Upload
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate songs JSON
+        run: python scripts/crear_songs_json.py
+      - name: Commit songs JSON
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add songs/songs-v*.json
+            git commit -m "chore: update songs JSON"
+            git push
+          fi
+      - name: Upload to Firebase
+        env:
+          FIREBASE_URL: ${{ secrets.FIREBASE_URL }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: python scripts/update_firebase.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # conversor-acordes
 Conversor de acordes en formato tabulado a formato Chord Pro
+## Automatizaci\xC3\xB3n de songs.json
+
+Este repositorio incluye un flujo de trabajo de GitHub Actions que genera
+autom\xC3\xA1ticamente la \xC3\xBAltima versi\xC3\xB3n de `songs.json` y la publica en Firebase.
+Cada vez que se hace push a la rama `main` se ejecutan las siguientes acciones:
+
+1. Se ejecuta `scripts/crear_songs_json.py` para crear un nuevo archivo
+   `songs-vX.json` en la carpeta `songs`.
+2. Si se ha generado un nuevo archivo, se confirma y sube el cambio al repositorio.
+3. El archivo resultante se env\xC3\xADa a la base de datos de Firebase y se
+   actualiza el campo `songs/updatedAt` con la marca de tiempo actual.
+
+Para que la publicaci\xC3\xB3n en Firebase funcione es necesario definir dos
+**Secrets** en el repositorio de GitHub:
+
+- `FIREBASE_URL`: URL base de la Realtime Database (por ejemplo
+  `https://tu-proyecto.firebaseio.com`).
+- `FIREBASE_TOKEN`: token con permisos de escritura en la base de datos.
+
+Una vez configurados, cualquier push a `main` crear\xC3\xA1 la nueva versi\xC3\xB3n de
+`songs.json`, la subir\xC3\xA1 al repositorio y actualizar\xC3\xA1 Firebase de forma
+autom\xC3\xA1tica.

--- a/scripts/update_firebase.py
+++ b/scripts/update_firebase.py
@@ -1,0 +1,50 @@
+import os
+import urllib.request
+import urllib.error
+import time
+import re
+
+
+def find_latest_version(songs_dir):
+    version_pattern = re.compile(r'^songs-v(\d+)(?:\.(\d+))?\.json$')
+    versions = []
+    for fname in os.listdir(songs_dir):
+        m = version_pattern.match(fname)
+        if m:
+            major = int(m.group(1))
+            minor = int(m.group(2)) if m.group(2) else 0
+            versions.append((major, minor, fname))
+    if not versions:
+        raise RuntimeError('No songs versions found')
+    versions.sort()
+    return versions[-1][2]  # return filename of latest version
+
+
+def main():
+    firebase_url = os.environ['FIREBASE_URL'].rstrip('/')
+    token = os.environ['FIREBASE_TOKEN']
+    songs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'songs')
+
+    latest_file = find_latest_version(songs_dir)
+    json_path = os.path.join(songs_dir, latest_file)
+
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = f.read().encode('utf-8')
+
+    def request(url, body):
+        req = urllib.request.Request(url, data=body, method='PUT', headers={'Content-Type': 'application/json'})
+        with urllib.request.urlopen(req) as resp:
+            resp.read()
+
+    # Update songs/data
+    url_data = f"{firebase_url}/songs/data.json?auth={token}"
+    request(url_data, data)
+
+    # Update songs/updatedAt with Unix timestamp
+    timestamp = str(int(time.time()))
+    url_time = f"{firebase_url}/songs/updatedAt.json?auth={token}"
+    request(url_time, timestamp.encode('utf-8'))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/update_firebase.py
+++ b/scripts/update_firebase.py
@@ -21,8 +21,14 @@ def find_latest_version(songs_dir):
 
 
 def main():
-    firebase_url = os.environ['FIREBASE_URL'].rstrip('/')
-    token = os.environ['FIREBASE_TOKEN']
+    firebase_url = os.environ.get('FIREBASE_URL')
+    if not firebase_url:
+        raise RuntimeError("Environment variable 'FIREBASE_URL' is required but not set.")
+    firebase_url = firebase_url.rstrip('/')
+
+    token = os.environ.get('FIREBASE_TOKEN')
+    if not token:
+        raise RuntimeError("Environment variable 'FIREBASE_TOKEN' is required but not set.")
     songs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'songs')
 
     latest_file = find_latest_version(songs_dir)

--- a/scripts/update_firebase.py
+++ b/scripts/update_firebase.py
@@ -39,8 +39,15 @@ def main():
 
     def request(url, body):
         req = urllib.request.Request(url, data=body, method='PUT', headers={'Content-Type': 'application/json'})
-        with urllib.request.urlopen(req) as resp:
-            resp.read()
+        try:
+            with urllib.request.urlopen(req) as resp:
+                resp.read()
+        except urllib.error.HTTPError as e:
+            print(f"HTTPError: {e.code} {e.reason} for URL: {url}")
+            raise
+        except urllib.error.URLError as e:
+            print(f"URLError: {e.reason} for URL: {url}")
+            raise
 
     # Update songs/data
     url_data = f"{firebase_url}/songs/data.json?auth={token}"


### PR DESCRIPTION
## Summary
- document automation in README
- add script to upload songs json to Firebase
- create workflow that generates songs json, commits it, and uploads to Firebase

## Testing
- `python -m py_compile scripts/crear_songs_json.py scripts/update_firebase.py`


------
https://chatgpt.com/codex/tasks/task_e_68823f49364083268a7a2c22aaf15afa