### PR TITLE
fix: corregir acordes inválidos en Gloria Genverde

### DIFF
--- a/songs/B. Gloria/08.gloria_genverde.cho
+++ b/songs/B. Gloria/08.gloria_genverde.cho
@@ -12,7 +12,6 @@ DE [A]BUENA V[B]OL[E]UNTAD. [A]GLOR[B]IA*
 
 {comment: * CANON ESTRIBILLO: Glooooria a Dios en el cielo, paz en la tierra a los hooombres, paz a los hombres de buena voluntad, gloooria}
 
-{comment: ACORDES POR ARREGLAR}
 [A]1. Te alabamos y [E]te bend[F#m]ecimos[E]
 [A]te adoramos, sea [E]gloria [D]a Ti[E]
 [A]y te damos graci[E]as por t[F#m]u inmensa [E]gloria.[D][B7]
@@ -25,9 +24,9 @@ DE [A]BUENA V[B]OL[E]UNTAD. [A]GLOR[B]IA*
 
 {comment: ** CANON ESTROFA 1: Señor Dios-nueeestro, rey-del-cieeeelo, gloria, tuuu Dios Paaadre, glooooriaaa}
 
-2 - S[E]eñor, Hijo unigénito, Je[D]suc[-]ri[A]sto,[E]
-[E]Señor, Cordero de Dios, Hijo [RE]del[A]
-Padre. [E]Tú q[E]ue quitas el pecado del [RE-LA]
+2 - S[E]eñor, Hijo unigénito, Je[D]sucri[A]sto,[E]
+[E]Señor, Cordero de Dios, Hijo [D]del[A]
+Padre. [E]Tú q[E]ue quitas el pecado del [D][A]
 mundo, ten piedad de nosotros,[E]
 
 Tú que quitas el pecado del 

--- a/songs/songs-v0.7.json
+++ b/songs/songs-v0.7.json
@@ -1,0 +1,778 @@
+{
+  "entrada": {
+    "categoryTitle": "A. Canciones Entrada 🎉",
+    "songs": [
+      {
+        "title": "01. Ven a Celebrar",
+        "filename": "01.ven_a_celebrar.cho",
+        "author": "Alborada",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ven a Celebrar}\n{artist: Alborada}\n{key: G}\n\n\n{soc}\n[G]VEN A CELEBRAR EL [bm]AMOR DE DIOS, [C]SE DERRAMARÁ COMO [G]AGUA LIMPIA  \n[C]EMPAPANDO NUESTRAS [G]VIDAS DE [C]SU [D]PRESENCIA (bis)\n{eoc}\n\n[Em]Os aseguro que [Bm]yo estaré [C]cuando [C]dos o más por [G]mí os reunáis.  \n[C]Es la mejor forma [G]de creer en [C]nuestra amistad, [D]en nuestra amistad...\n\nNos has traído al desierto para hablarnos al corazón \ny transformar nuestras vidas con tus palabras de amor, \npalabras de amor..."
+      },
+      {
+        "title": "02. Dios Está Aquí",
+        "filename": "02.dios_esta_aqui.cho",
+        "author": "",
+        "key": "C",
+        "capo": 1,
+        "info": "",
+        "content": "\n{title: Dios Está Aquí}\n{key: C}\n{capo: 1}\n\n{soc}\n[C]DIOS ES[G]TÁ A[Am]QUÍ TAN [F]CIERTO COMO EL AIRE [G]QUE [C]RESPIRO [C7] \nTAN [F]CIERTO COMO LA [G]MAÑANA SE LE[C]VAAA[Em]AAAAN[Am]TA  \nTAN [F]CIERTO COMO [G]QUE ESTE CANTO LO PUEDES [C]OÍR  \n{eoc}\n\nLO PUEDES [G]SENTIR MO[F]VIÉNDOSE ENTRE LOS QUE [C]AMAN  \nLO PUEDES [G]OÍR CAN[F]TANDO CON NOSOTROS [C]AQUÍ  \nLO PUEDES LLE[G]VAR CUAN[F]DO POR ESA PUERTA [C]SALGAS  \nLO PUEDES GUAR[G]DAR POR SI[F]EMPRE EN [G]TU CORA[G]ZÓN [G7]\n"
+      },
+      {
+        "title": "03. Herederos",
+        "filename": "03.herederos.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "C",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Herederos}\n{artist: Nati Escudero, nsc}\n{key: C}\n{capo: 1}\n\n\n{soc}\nVE[C]NID BEND[F]ITOS DE MI P[C]ADRE \nHERE[Am]DAD EL REINO DE SU [G]AMOR \nPORQUE T[C]UVE HAMBRE Y [F]SED\nY ME [Am]DISTEIS DE C[G]OMER Y DE B[C]EBE[G]R\n{eoc}"
+      },
+      {
+        "title": "04. Ven a la Fiesta",
+        "filename": "04.ven_fiesta.cho",
+        "author": "Toño Casado",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ven a la Fiesta}\n{artist: Toño Casado}\n{key: D}\n\n\n{soc}\nV[D]EN [A]A LA [Bm]FIESTA ES EL M[G]OMENTO DE RE[Em]ZAR Y DE CAN[A]TAR\n[D]HOY [A]CELE[Bm]BRAMOS QUE EN NUESTRAS [G]VIDAS DIOS VIVI[A]ENDO SIEMPRE ES[D]TÁ\n{eoc}\n\n[G]Ven a la f[A]iesta a [D]part[A]ici[Bm]par, [G]nos hace falta [A]tu calor[Bm]\n[G]Jesús te inv[A]ita para [D]cele[A]brar su [Bm]amor\nAte[C]nto tú estar[A]ás a responder por eso"
+      },
+      {
+        "title": "05. Ven, no lo dudes",
+        "filename": "05.ven_no_lo_dudes.cho",
+        "author": "",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ven, no lo dudes}\n{artist: }\n{key: D}\n\n[D]Si piensas que e[G]sta noche ha sid[D]o de esas para o[A]lvidar\nSi apena[D]s has pegado ojo [G]y te tienes que [D]levantar[A]\nSi en la [D]cabeza mil hist[G]orias no paran d[D]e molestar[A]\nSi el estrés, la [D]pris[A]a, el mi[Bm]edo, te acompaña[G]n al [A]andar[D]\n\n{soc}\n[D]VEN, NO LO [G]DUDES NO LO [D]PIENSES, TOMA [F#m]FUERZA Y SE [Bm]VALIENTE \nTE IN[G]VITO A CELE[A]BRAR\n[D]VEN AL EN[G]CUENTRO DE LA [D]GENTE, DE LA [F#m]VIDA Y DE SU [Bm]SUERTE \n[G]DESDE NIÑO[A]HASTA ABUELO\n[F#m]SIEMPRE ES CRISTO QUIEN SE [Bm]PONE EN MEDIO\nESTA[G] ES LA FIESTA, DEL [A]PAN DE, LA UNI[D]DAD.\n{eoc}\n\n[D]Si la vida te sonríe o [G]es la espalda la [D]que te da[A]\n[D]Si eres pobre y t[G]e haces rico y [D]del suelo levant[A]aras\n[D]Si vas de chulo [G]y te sobra todo, si está[D]s pasando hasta de pasar[A]\n[D]O Si te importa el que [G]está a tu lado y estás ca[D]nsado de descansar.[A]"
+      },
+      {
+        "title": "06. Nos reunimos aquí",
+        "filename": "06.nos_reunimos_aqui.cho",
+        "author": "Expresarte",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Nos reunimos aquí}\n{artist: Expresarte}\n{key: G}\n\n\n{soc}\n[G]NOS REUNIMOS AQUÍ, AL PAR[C]TIR EL [G]PAN,\nDANDO G[G]RACIAS EN TU NOMBRE, AL PAR[C]TIR EL [D]AN,\nRECOR[G]DANDO TU PALABRA, AL PAR[Bm]TIR EL [Em]PAN,\nFOR[C]MANDO UN SOLO C[G]UERPO CAMI[C]NAMOS A TU [G]ALTAR,\nALZ[C]ANDO NUESTRAS [G]VOCES AL [F]PARTIR EL P[C]AN. (2)\n{eoc}\nNeces[G]itamos de tu Pan y de tu [D]Vino,\ny que hagamos el c[C]amino como un solo cora[D]zón.\nNecesi[G]tamos ofrecerte nuestras [D]vidas\nceleb[F]rar el gran misterio de tu [C]muerte y resurrecc[D]ión\n\nNecesitamos que resuenen que tus perdones nuestras faltas, que resuenen tus palabras que cantemos al amor\nNecesitamos ofrecerte nuestras vidas, que la paz sea con nosotros, recibir tu bendición."
+      },
+      {
+        "title": "07. Somos Hijas de la Iglesia",
+        "filename": "07.somos_hijas_iglesia.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Somos Hijas de la Iglesia}\n{artist: Inma Vírseda}\n{key: D}\n\n\n{soc}\nSOMOS  HIJAS  DE  [D]LA  IGLESIA  ([A]bis).  S[Bm]OMOS  HI[G]JAS  DE  LA  IG[D]LESIA  PARA CONS[Bm]OLAR.  (b[D]is)\n{eoc}\n[C]Iglesia  Ma[G]dre,  [D]por  el  bautismo  [F#m]nos  engendraste  a  LA  san[G]tidad.  Iglesia, [A][F#m]\n[G]Maestra, [Bm]nos ens[Em]eñas, có[Bm]mo hoy p[Em]roclamar a Cristo [A]Vida, Camino y Verdad."
+      },
+      {
+        "title": "08. Viviré Alabándote",
+        "filename": "08.vivire_alabandote.cho",
+        "author": "Maite López",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Viviré Alabándote}\n{artist: Maite López}\n{key: G}\n\n{soc}\n[G]Viviré alabánd[D]ote, adoránd[C]ote y sirviénd[G]ote\n[Em]toda mi cap[Bm]acidad de amar [C]es para ti (b[D]is)\n{eoc}\n[Am]Todo lo que tengo es [D]tuyo, [Am]en todo puedo encontrar[D]te\n[B7]haz que sepa utilizar[C]lo, solo [G]si me ayuda amar[D]te."
+      },
+      {
+        "title": "09. Aclamad Cielos",
+        "filename": "09.aclamad_cielos.cho",
+        "author": "",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aclamad Cielos}\n{key: D}\n\n\n{soc}\nACLAM[D]AD CIELOS, EXULTA [Bm]TIERRA\nPORQUE Y[Em]AVEH HA CONSOLADO A S[A]U PUEBLO\t[D]\nY DE SUS POBRES SE [Bm]HA COMPA[Em]DECI[A]DO[D]\n{eoc}\n\n[D]En tiempo fav[Bm]orable te escucho, [Em]yo te formé[A][D]\nY t[Bm]e he desti[D]nado a [G]ser alianza de un p[A]ueblo, d[D]ice el Señ[A]or."
+      },
+      {
+        "title": "12. Surgirá un Mundo Nuevo",
+        "filename": "12.surgira_mundo_nuevo.cho",
+        "author": "Verbum Dei",
+        "key": "C",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Surgirá un Mundo Nuevo}\n{artist: Verbum Dei}\n{key: C}\n{capo: 2}\n\n\n{soc}\nSURGI[C]RÁ UN MUNDO NUEVO LEVAN[G]TADO POR LA FUERZA DEL A[C]MOR \nHECHO POR HOMBRES CON EL CORAZON [G]ABIERTO AL ESPIRITU DE  [C]DIOS\nY SU [F]LEY SERA EL PERDON Y SU JUST[Am]ICIA EL AMOR,\nPOR LA [F]FUERZA DE SU [G]FE EN EL SE[C]ÑOR.\n{eoc}\n\n[C]Un solo Dios nos re[G]úne en su paz, \nderri[F]bando las murallas con que [G]fuimos separados. \nUn s[C]olo bautismo una [G]misma fe, por su [F]cruz Él ha vencido a la muerte,  ha c[Dm]reado en si [G]mismo un hombre [C]nuevo[G]..."
+      },
+      {
+        "title": "20. Seas Quien Seas",
+        "filename": "20.seas_quien_seas.cho",
+        "author": "TSNC",
+        "key": "C",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Seas Quien Seas}\n{artist: TSNC}\n{key: C}\n{capo: 2}\n\n{soc}\n[C]Seas quien seas y co[G]mo seas\n[F]esta es tu [C]casa, acérca[G]te.\n[F]Abre tus [C]manos, [E7]mira a los [Am]lados,\n[F]siéntete [C]libre para [G]ser.\n{eoc}\n[C]Hay muchas formas de o[G]rar,\n[Am]tantas como per[Em]sonas\n[F]nos reunimos a la m[C]esa\n[F]y celebramos jun[G]tas.\n\nSi levantas la mirada,\nVerás a quien te rodea.\nAbre el corazón, sonríe,\nla comunidad alienta.\n\n{soc}\nSeas quien seas…\n{eoc}\n\nPorque juntas somos más,\nSomos hijas de un Dios tierno.\nEl Espíritu nos llena\ny Jesús aparta el miedo.\n\nNingún cabo está suelto,\nen tu casa nadie sobra.\nÉl nos llama todo el tiempo,\nama tanto que desborda.\n\n{soc}\nSeas quien seas…\n{eoc}\n\n\nVas notando la alegría,\nsientes un calor distinto.\nSe van llenando los huecos:\nes Jesús, sigue su ritmo.\n\nDescubrirás lo que resuena,\nte moverás según su sueño,\nentregarás toda tu vida\na los demás, sea quien sea.\n\n{soc}\nSeas quien seas…\n{eoc}\n"
+      }
+    ]
+  },
+  "gloria": {
+    "categoryTitle": "B. Gloria - Piedad 🙏🏼",
+    "songs": [
+      {
+        "title": "08. Gloria",
+        "filename": "08.gloria_genverde.cho",
+        "author": "Genverde",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Gloria}\n{artist: Genverde}\n{key: E}\n\n\n{soc}\n[E]GLORIA, [A]GLORIA A [C#m]DIOS[B].    \nGLORIA, [E]GLORIA [A]A DIOS EN EL [C#m]CIELO, [B]  \n[E]PAZ EN LA TI[A]ERRA A LOS [C#m]HOMBRE[B]S\nDE [A]BUENA V[B]OL[E]UNTAD. [A]GLOR[B]IA*\n{eoc}\n\n{comment: * CANON ESTRIBILLO: Glooooria a Dios en el cielo, paz en la tierra a los hooombres, paz a los hombres de buena voluntad, gloooria}\n\n[A]1. Te alabamos y [E]te bend[F#m]ecimos[E]\n[A]te adoramos, sea [E]gloria [D]a Ti[E]\n[A]y te damos graci[E]as por t[F#m]u inmensa [E]gloria.[D][B7]\n\n[A]Señor, Dios nuestro, gloo[E]ooria.[F#m][E]\n[A]Rey del cielo, gl[E]oria. [D][E]\n[A]Tú Dios Padre, Dios o[E]mnipotent[F#m]e. [E]\n[D]Glori[B7]a.**\n\n\n{comment: ** CANON ESTROFA 1: Señor Dios-nueeestro, rey-del-cieeeelo, gloria, tuuu Dios Paaadre, glooooriaaa}\n\n2 - S[E]eñor, Hijo unigénito, Je[D]sucri[A]sto,[E]\n[E]Señor, Cordero de Dios, Hijo [D]del[A]\nPadre. [E]Tú q[E]ue quitas el pecado del [D][A]\nmundo, ten piedad de nosotros,[E]\n\nTú que quitas el pecado del \nmundo, atiende nuestras súplicas, [E]\nTú que estás a la derecha del \nPadre, ten piedad [A]de nosotros.[B]\n\n3 - Porque [A]Tú sólo el Sant[E]o, el Se[F#m]ñor. [E]\nTú sólo el [A]Altísimo, Crist[E]o Jesús, [D]con el [E][A]\nSanto Es[E]píritu en [F#m]la Gloria [E]del Padre***[D][B]\n\n{comment: *** CANON ESTROFA 3: Jeeesucristo con el saaanto-espíritu eeen la Gloooria del Paaadre}"
+      }
+    ]
+  },
+  "salmos": {
+    "categoryTitle": "C. Salmos 📚",
+    "songs": [
+      {
+        "title": "01. Salmo 15 - El Lote de mi Heredad",
+        "filename": "01.salmo15_lote_heredad.cho",
+        "author": "Desde el Silencio",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{artist: Desde el Silencio}\n{title: Salmo 15 - El Lote de mi Heredad}\n{key: D}\n\n{comment: Intro: RE | LA | sim | SOL | RE | LA}\n\n{soc}\nEL [D]SEÑOR ES EL [A]LOTE DE MI [Bm]HEREDAD, [G]AAAA[D]LELUUU[A]YA  \nPOR [Bm]SIEMPRE MI ALMA TE [A]CANTARÁ, [G]AAAA[A]LELUUU[D]YA  \n{eoc}\n\n1. Pro[bm]tégeme Dios [G]mío, me re[D]fugio en ti. [G]Yo digo al Señor tú eres MI [A]bien.  \nLos [G]dioses y señores de la [A]tierra [G]no me [A]satis[D]facen.  \n\n2. [D]El Señor es el [A]lote de mi here[bm]dad. Mi [G]suerte está en tu [A]mano.  \n[G]  Me ha tocado un lote her[A]moso, me en[G]canta [A]mi here[D]dad. [A] \n\n3. Bendeci[D]ré al Se[A]ñor que me acon[Bm]seja. Hasta de [G]noche me instruye interna[A]mente.  \n[D]Tengo [A]siempre pre[G]sente al Se[A]ñor, con [G]él a mi de[A]recha, [G]no va[A]cila[D]ré..[A]. \n\n4. Me enseña[D]rás el sen[A]dero de la vida, [em]me saciarás, de [G]gozo en tu pre[D]sencia  \nde ale[A]gría... \nPor [D]siempre a tu de[A]recha (bis)\n"
+      },
+      {
+        "title": "02. Salmo 23 - El Señor es Mi Pastor",
+        "filename": "02.salmo23_senor_pastor.cho",
+        "author": "Nico Montero",
+        "key": "G",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Salmo 23 - El Señor es Mi Pastor}\n{artist: Nico Montero}\n{key: G}\n{capo: 1}\n{soc}\nEL [G]SEÑOR ES MI [D]PASTOR NADA ME [Em]FALTA, EL [C]SEÑOR ES [Am]MI PAS[D]TOR\nEL [G]SEÑOR ES MI [D]PASTOR NADA ME [Em]FALTA, EL [C]SEÑOR ES [Am]MI PAS[D]TOR..[G].\n{eoc}\n\n1. En pra[G]deras reposa mi alma,\nen su ag[Bm]ua descansa mi sed.\nEl me gu[Em]ía por senderos j[C]ustos\npor a[Am]mor, por amor de su n[D]ombre.\n\nAunque [G]pase por valles oscuros\nningún [Bm]mal, ningún mal temeré\nporque [Em]se que el Señor va con[C]migo\nsu [Am]cayado [A7]sostiene mi [D]feee[D7]ee....\n\n{soc}\nEL [G]SEÑOR ES MI [D]PASTOR NADA ME [Em]FALTA, EL [C]SEÑOR ES [Am]MI PAS[D]TOR\nEL [G]SEÑOR ES MI [D]PASTOR NADA ME [Em]FALTA, EL [C]SEÑOR ES [Am]MI PAS[D]TOR..[G].\n{eoc}\n\n2. Tu pre[G]paras por mi una mesa\nfrente a[Bm] aquellos que buscan mi mal.\nCon ace[Em]ite me ungiste ,S[C]eñor\ny mi cop[Am]a rebosa de [D]ti.\n\nGloria a [G]Dios, padre omnipotente\ny a su [Bm]hijo Jesús, el Señor\ny al [Em]Espíritu que habita en el [C]mundo\npor los [Am]siglos [A7]eternos a[D]méeee[D7]eeeen...\n"
+      },
+      {
+        "title": "03. Salmo 145 - Alma Mía",
+        "filename": "03.salmo145_alma_mia.cho",
+        "author": "Anabel Jiménez",
+        "key": "C",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Salmo 145 - Alma Mía}\n{artist: Anabel Jiménez}\n{key: C}\n{capo: 3}\n\n\n{soc}\nALMA [C]MIA, A[G]LABA AL SE[C]ÑOR, ALABARE AL SE[G]ÑOR MIENTRAS VIVA \nT[F]AÑERÉ[G] PARA MI DI[C]OS, MIENTRAS EXISTA, [F]TAÑERÉ PA[G]RA MI [C]DIOS\n{eoc}\n\n[Am]No confiéis en los [Em]príncipes, seres de p[F]olvo que no [G]puedo sal[C]var.\n  [C]        [Em]        [Am]Dichoso a quien auxi[Em]lia Dios, el que es[F]pera [G]en el Se[C]ñor. \n  [C]        [Em]        [Am]Que hace justicia a los oprimidos, que da pan al que tiene hambre,  [G]   que es Dios por siempre fiel…\nPorque no [F]quiebra la caña cascada y apaga el car[C]bón encendido[G].\n\n\n\n{soc}\nALMA [C]MIA, A[G]LABA AL SE[C]ÑOR, ALABARE AL SE[G]ÑOR MIENTRAS VIVA \nT[F]AÑERÉ[G] PARA MI DI[C]OS, MIENTRAS EXISTA, [F]TAÑERÉ PA[G]RA MI [C]DIOS\n{eoc}\n\n[Am]El Señor lib[Em]erta a los cautivos, el S[F]eñor abre los o[G]jos al [C]ciego. [Em]    [Am]               \n[Am]l guarda a los  [Em]peregrinos, Él es el [F]padre del[G]hijo h[C]uérfano  [Em]    [Am]                    \nN[Am]uestro Dios ama a los justos, reina por la eternidad,  [G]   endereza a los que ya se doblan\nPorque no [F]quiebra la caña cascada ni apaga el carbó[C]n encendido[G].\n\n{soc}\nALMA [C]MIA, A[G]LABA AL SE[C]ÑOR, ALABARE AL SE[G]ÑOR MIENTRAS VIVA \nT[F]AÑERÉ[G] PARA MI DI[C]OS, MIENTRAS EXISTA, [F]TAÑERÉ PA[G]RA MI [C]DIOS\n{eoc}"
+      },
+      {
+        "title": "04. Salmo 115 - ¿Cómo te podré pagar?",
+        "filename": "04.salmo115_como_podre_pagar.cho",
+        "author": "Belén Raigal, nsc",
+        "key": "Dm",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Salmo 115 - ¿Cómo te podré pagar?}\n{artist: Belén Raigal, nsc}\n{key: Dm}\n{capo: 1}\n\n\n[C]¿CÓMO [C]TE PODRÉ PA[F]GAR POR TANTO [Em]BIEN QUE ME HAS HECHO? \n¿CÓMO [F]PUEDO AGRADE[D7]CER TU GRAN BON[G]DAD?\n\n1. Alza[C]ré la copa [F]de la salva[C]ción, invo[Am]cando el nombre [D7]del Se[G]ñor. Cumpli[Em]ré al Señor mis [Am]votos, todo el [F]pueblo lo pre[G]sencia[C]rá. (Bis)\n\n2. Quiero [C]proclamar tu [F]nombre, eres [C]mi Señor, soy tu [Am]siervo, ¿cómo [F]puedo agrade[G]cer? Mira[Em]ré siempre tu [Am]rostro, junto a [F]ti yo quiero [G]cami[C]nar. (Bis)\n\n3. Has sol[C]tado mis ca[F]denas, te a[C]labaré y mi [Am]vida ante tu al[D7]tar ofrece[G]ré. Cumpli[Em]ré al Señor mis [Am]votos, todo el [F]pueblo lo pre[G]sencia[C]rá.(Bis)\n"
+      },
+      {
+        "title": "06. Salmo 33 - Gustad y Ved",
+        "filename": "06.salmo33_gustad_y_ver.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Salmo 33 - Gustad y Ved}\n{artist: Inma Vírseda}\n{key: D}\n\n\n1. [D] Bendigo [A]siempre al Señor[G], su alabanza es[A]tá siempre en mi boca,[F#m] mi alma se glo[Bm]ría en el Señor,[G] que los humildes lo es[A]cuchen y se alegren.\n{soc}\nGUS[Em]TAD Y VED QUÉ  [A]BUENO ES, DI[F#m]CHOSO EL QUE SE A[Bm]COGE A ÉL. GUS[Em]TAD Y VED QUÉ [A]BUENO ES NUESTRO [D]DIOS. (Bis)\n{eoc}\n2. [D]Persigue y [A]busca la paz,[G] haz el bien y vence[A] al mal.[F#m] Clamó este [Bm]pobre a Yahvé,[G] y lo libró de [A]todas sus angustias.\n{soc}\nGUS[Em]TAD Y VED QUÉ  [A]BUENO ES, DI[F#m]CHOSO EL QUE SE A[Bm]COGE A ÉL. GUS[Em]TAD Y VED QUÉ [A]BUENO ES NUESTRO [D]DIOS. (Bis)\n{eoc}\n"
+      },
+      {
+        "title": "07. Salmo 4 - En el aprieto",
+        "filename": "07.salmo4_en_el_aprieto.cho",
+        "author": "Belén Raigal, nsc",
+        "key": "C",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Salmo 4 - En el aprieto}\n{artist: Belén Raigal, nsc}\n{key: C}\n{capo: 1}\n\n{comment: Intro: lam | SOL | DO | SOL  x2}\n\n\n{soc}\n[C]TÚ QUE EN EL A[G]PRIETO ME DISTE AN[Am]CHURA, QUE EN EL DO[Em]LOR FUISTE MI CON[F]SUELO, [Dm]TEN PIEDAD DE [G]MI, ESCUCHA MI ORA[C]CIÓN[G] (bis){eoc}\n\nSa[C]bedlo, el Señor hizo mi[G]lagros, que [Am]tiemble el corazón en su pre[Em]sencia, [F]ofreced la [G]vida con sinceri[C]dad y confiad en [E]el Señor.  \n\n{comment: Instrumental: lam | SOL | DO | SOL  x2}\n\n\nMi [C]corazón se llena de [G]alegría, con[Am]tigo mucho más que mil [Em]tesoros, [F]que tu luz sea mi [G]luz y solo tú mi [C]Dios[E]\n\n{soc}\n[C]TÚ QUE HAS REGA[G]LADO DE PAZ MI [Am]VIDA, QUE SOLO EN [Em]TI PUEDO ESTAR TRAN[F]QUILO, [Dm]TEN PIEDAD DE [G]MI, ESCUCHA MI ORA[C]CIÓN[G].\n[C]TÚ QUE EN EL A[G]PRIETO ME DISTE AN[Am]CHURA, QUE EN EL DO[Em]LOR FUISTE MI CON[F]SUELO, [Dm]TEN PIEDAD DE [G]MI, ESCUCHA MI ORA[C]CIÓN[G]. \n\n[C]TÚ QUE HAS REGA[G]LADO DE PAZ MI [Am]VIDA, QUE SOLO EN [Em]TI PUEDO ESTAR TRAN[F]QUILO, [Dm]TEN PIEDAD DE [G]MI, ESCUCHA MI ORA[C]CIÓN[G]\n[C]\n{eoc}\n"
+      },
+      {
+        "title": "08. Salmo 26 - Desde Dentro",
+        "filename": "08.salmo26_desde_dentro.cho",
+        "author": "Paula Maran",
+        "key": "A",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Salmo 26 - Desde Dentro}\n{artist: Paula Maran}\n{key: A}\n{capo: 3}\n\n[A]  Eres tú el que me puede juzgar, Eres [D]Tú el que hace firme mi caminar, oh\n[A] Solo en ti sé que puedo confiar, solo en [D]ti nunca nadie me hará dudar\nExa[Bm]míname por [D]dentro quiero \t[A]conocerme [E]más\nPona [Bm]prueba mis la[D]tidos y mi fe\n\n\n{soc}\n[A]  QUIERO ENCONTRAR REFUGIO EN [E]TI\nPONGO MI TIEMPO MI NE[D]CESIDAD, HAZ DE MI LO QUE TÚ QUIERAS\nPOQUE DAS [A]LUZ A MI MIRADA CUANDO CA[E]MINO EN TU PRESENCIA\nME HACES [D]RESPIRAR, [G]HAZ DE MI TU VOLUNTAD\n{eoc}\n\n[A] Con mi voz te agradeceré, canto [E]por todo aquello que me hiciste ver\n[A] Y guárdame muy cerca de ti, abr[E]ázame y mis pies andarán al fin.\nExa[Bm]míname por [D]dentro quiero \t[A]conocerme [E]más\nPona [Bm]prueba mis la[D]tidos y mi fe\n\n{soc}\n[A] QUIERO ENCONTRAR REFUGIO EN [E]TI\nPONGO MI TIEMPO MI NE[D]CESIDAD, HAZ DE MI LO QUE TÚ QUIERAS\nPOQUE DAS [A]LUZ A MI MIRADA CUANDO CA[E]MINO EN TU PRESENCIA\nME HACES [D]RESPIRAR, [G]HAZ DE MI TU VOLUNTAD\n{eoc}"
+      },
+      {
+        "title": "11. Salmo 8 - Grande es tu Amor",
+        "filename": "11.salmo8_grande_es_tu_amor.cho",
+        "author": "Glenda",
+        "key": "C",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Salmo 8 - Grande es tu Amor}\n{artist: Glenda}\n{key: C}\n\n\n{soc}\nG[C]RANDE ES TU AMOR, [G]GRANDE TU MISERICORDIA,  \n[Am]GRANDE ES[lam\t\t\tmim\t\t\tFA\tSOL] TU [Em]NOMBRE POR TODA LA [F]TIERRA[G] (bis)\n{eoc}\n\n[C]Cuando contemplo el [Am]cielo [F]obra de [G]tus manos,  [C]la luna y las [Am]estrellas que [F]has cre[G]ado. \n[C]Pienso que soy yo p[Am]ara que [F]piens[G]es en mí.  Piens[C]o que soy [Am]yo para que pie[F]nses en [G]mí, en mí. "
+      },
+      {
+        "title": "12. Que se alegren tus entrañas - Isaías 60",
+        "filename": "12.isaias60_que_se_alegren.cho",
+        "author": "Ain Karem",
+        "key": "A",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Que se alegren tus entrañas - Isaías 60}\n{artist: Ain Karem}\n{key: A}\n\n\n{soc}\nQ[A]UE SE ALE[D]GREN T[A]US ENTR[D]AÑAS T[A]EN ALE[D]GRE EL CORA[E]ZÓN TU L[F#m]UZ \nPERPETUA ES EL SEÑ[C#m]OR, Y TU DI[D]OS SERÁ TU RESPLAND[E]OR.\n{eoc}\n\n1. De[F#m]scansa[D] en l[A]a ce[D]rteza de que[E] el Se[F#m]ñor es tu luz. No se pondrá nunca \nel S[D]OL sobre tus días ni t[LA]u luna se oscu[D]recerá. El luto y el llanto han \nce[F#m]sado, h[]aaa[E]an cesadooo\n\n2. Anuncia la bondad del Señor, que te llamó de la oscuridad a la luz. Alégrate confiada, porque nada de lo humano le es ajeno. Su presencia serena y firme purifica, restaura, sana.\n\n3. Ensancha el corazón, conocerás los frutos del amor: del compromiso por la justicia brotarán lazos de fraternidad. El Señor lo hará con prontitud y amanecerá la humanidad reconciliada"
+      },
+      {
+        "title": "13. Salmo 114 - Alma mía recobra tu calma",
+        "filename": "13.salmo114_alma_mia_recobra_tu_calma.cho",
+        "author": "Inma Vírseda",
+        "key": "Dm",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Salmo 114 - Alma mía recobra tu calma}\n{artist: Inma Vírseda}\n{key: Dm}\n\n{soc}\nALMA [Dm]MÍA RE[C]COBRA TU [Dm]CALMA QUE EL SEÑOR[Bb] FUE [C]BUENO CON[Dm]TIGO (BIS)\n{eoc}\n\n1. [Dm]Amo al [C]Señor porque es[Dm]cucha mi [Bb]voz [C]supli[Dm]cante. Porque inclina su [C]oído hacia [Dm]mí, el [Bb]día [C]que lo in[Dm]voco (Bis).\n\n2. Me envol[Dm]vían [C]redes de [Dm]muerte, me alcan[Bb]zaron [C]los lazos del a[Dm]bismo. Caí en [C]tristeza y an[Dm]gustia. Invo[Bb]qué el [C]nombre del [Dm]Señor: “¡Se[Bb]ñor [C]salva mi [Dm]vida!”.\n\n3. El Se[Dm]ñor es [C]benigno y [Dm]justo, nuestro [Bb]Dios es [C]compasivo. El Se[Dm]ñor guarda [C]a los sen[Dm]cillos. Es[Bb]tando yo [C]sin fuerzas me [Dm]salvó. (Bis)\n\n4. Arran[Dm]có mi [C]alma de la [Dm]muerte y mis [Bb]ojos [C]de las [Dm]lágrimas. Arrancó mis [C]pies de la ca[Dm]ída. Camina[Bb]ré en pre[C]sencia del [Dm]Señor, [Bb]en el [C]país de la [Dm]vida.\n"
+      },
+      {
+        "title": "14. Ha 3 - Cántico de Habacuc",
+        "filename": "14.cantico_habacuc.cho",
+        "author": "Belén Raigal, nsc",
+        "key": "D",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Ha 3 - Cántico de Habacuc}\n{artist: Belén Raigal, nsc}\n{key: D}\n{capo: 3}\n\n\n1. Se[D]ñor, he oído tu [E]mfama,[A] tu obra me ha impresio[D]nado. Lo escuché y tem[Em]blaron mis entrañas,[G] al oírlo se estremeció mi [A]voz.[G] En medio de los [A]años manifiésta[D]la;[G] en medio de los [A]años realíza[D]la[G] y ten [A]miseri[D]cordia.\n\n2. [D] El Señor vi[A]ene de Temán,[Bm] el santo del [F#m]monte Farán;[G] su resplandor[Em] eclipsa el [D]cielo. Sales a sal[A]var a tu pueblo,[Bm] sales a sal[F#m]var a tu Ungido,[G] pisas el [Em]mar con tus ca[D]ballos. Lo escuché y tem[Em]blaron mis entrañas,[G] al oírlo se estremeció mi [A]voz.\n\n3. [G] Y aunque la hi[A]guera no echa [Bm]yemas[G] y las [Em]viñas no tienen [A]fruto[G] y los [Em]campos no dan co[D]secha, yo exulta[Em]ré con el Señor,[G] me gloriaré en Dios, mi salva[A]dor.\n\n4. [[D] El Señor sobe[A]rano es mi fuerza,[Bm] él me da [F#m]piernas de gacela,[G] me hace cami[Em]nar por las al[D]turas. Yo exultar[Em]é con el Señor,[Cl] me gloriaré en Dios mi salva[A]dor. [D]\n"
+      },
+      {
+        "title": "16. Ven Espíritu Creador",
+        "filename": "16.ven_espiritu_creador.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "Em",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ven Espíritu Creador}\n{artist: Nati Escudero, nsc}\n{key: Em}\n\n\n{comment: Intro: mim | RE | lam x4}\n{soc}\n[Em] VEN ES[D]PÍRITU CRE[Am]ADOR,[Em] VEN ES[D]PÍRITU CRE[Am]ADOR. \n{eoc}\n1. Y vi[Em]sita las [D]almas de tus[G] fieles, [Am]llena de tu gracia el cora[B7]zón. Don de [Em]Dios, [D]fuente [Am]viva, [Em]fuego, caridad, un[G]ción espíritu[B7]al.\n{soc}\n[Em] VEN ES[D]PÍRITU CRE[Am]ADOR,[Em] VEN ES[D]PÍRITU CRE[Am]ADOR. \n{eoc}\n2. Tú la [Em]mano de Dios el prome[D]tido del[G] Padre, [Am]pon en nuestros labios su Pa[B7]labra. In[Em]funde en [D]nuestro cora[Am]zón el[Em] fuego de tu amor, forta[G]lece nuestra débili[B7]dad.\n{soc}\n[Em] VEN ES[D]PÍRITU CRE[Am]ADOR,[Em] VEN ES[D]PÍRITU CRE[Am]ADOR. \n{eoc}\n3. Y en[Em]ciende con tu luz [D]nuestros sen[G]tidos, [Am]tú nuestro consuelo danos [B7]paz. Y por [Em]ti conoz[D]camos al[Am] Padre, y al [Em]Hijo y que en ti, cre[G]amos por los siglos. A[B7]mén.\n{soc}\n[Em] VEN ES[D]PÍRITU CRE[Am]ADOR,[Em] VEN ES[D]PÍRITU CRE[Am]ADOR (4)\n{eoc}\n\n"
+      },
+      {
+        "title": "17. El Senyor",
+        "filename": "17.el_senyor.cho",
+        "author": "Taizé",
+        "key": "F",
+        "capo": 0,
+        "info": "",
+        "content": "{title: El Senyor}\n{artist: Taizé}\n{key: F}\n\n\n{soc}\nE[rem]L SE[C]NY[F]OR ÉS LA MEVA F[SIb]ORÇ[C]A\nE[rem]L SE[C]NY[F]OR EL M[SIb]EU C[C]ANT.\n{eoc}\n                       SIb       DO     rem\n\n{soc}\nELL M'HA ESTAT LA SALVACIÓ.\nEN E[C]LL CONF[F]IO I N[SIb]O TINC P[C]OR.\n{eoc}\n      rem       SIb     rem DO   FA\n\n{soc}\nEN ELL CONFIO I NO TINC POR.\n{eoc}"
+      },
+      {
+        "title": "18. Salmo 32 - Que la tierra entera",
+        "filename": "18.salmo32_que_la_tierra.cho",
+        "author": "Belén Raigal, nsc",
+        "key": "G",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Salmo 32 - Que la tierra entera}\n{artist: Belén Raigal, nsc}\n{key: G}\n{capo: 2}\n\n[G]Aclamemos todos [Am]juntos, al Señor que nos re[G]úne, pues merece la ala[Am]banza de aquellos que Él se escogi[G]ó. [C]Tocad en su honor el [D]arpa y la [G]cítara, instru[C]mentos que ale[D]gren su cora[G]zón; cantad[B7]le un cántico un[Em]evo, ¡[C]demos [D]gracias al Se[G]ñor! \nSu Palabra es sin[Am]cera, es leal, llena la tie[G]rra, hizo el cielo y con su ali[Am]ento los ejércitos cre[G]ó. Que la [C]tierra entera [D]cante su ala[G]banza, porque [Am]Él lo dijo y todo exis[G]tió; quiso al [B7]hombre en su pre[Em]sencia, [C]por su Es[D]píritu de a[G]mor.\n\n{soc}\nQUE LA TI[C]ERRA EN[D]TERA [G]CANTE, POR SU [Am]]AMOR TODO EXIS[D]TIÓ. \nQUE LA TI[C]ERRA EN[D]TERA [G]CANTE, DEMOS [C]GRACIAS [D]AL SE[G]ÑOR. \n{eoc}\n\n[G]Mira el Señor a los fi[Am]eles que esperan miseri[G]cordia, de la muerte nos res[Am]cata y nos sacia con su a[G]mor. Aguar[C]damos confi[D]ados al Se[G]ñor, pues con [Am]Él se alegra nuestro cora[G]zón; baje a [B7]nosotros tu [Em]gracia [C]y nos [D]haga prospe[G]rar. \n[G]Su Palabra nos da [Am]vida, es la luz en el cami[G]no, nunca dejes de mi[Am]rarnos, trátanos según tu [G]amor. A la [C]luz de tu Pa[D]labra cami[G]namos, sólo en [Am]ti descansa nuestro cora[G]zón, muéstra[B7]nos, Señor tu ros[Em]tro, [C]tu pre[D]sencia es nuestra [G]paz. \n\n{soc}\nQUE LA TI[C]ERRA EN[D]TERA [G]CANTE, POR SU [Am]]AMOR TODO EXIS[D]TIÓ. \nQUE LA TI[C]ERRA EN[D]TERA [G]CANTE, DEMOS [C]GRACIAS [D]AL SE[G]ÑOR. \n{eoc}\n"
+      },
+      {
+        "title": "19. Salmo 42 - Como busca la cierva",
+        "filename": "19.salmo42_cierva.cho",
+        "author": "Belén Raigal, nsc",
+        "key": "Em",
+        "capo": 2,
+        "info": "",
+        "content": "\n{title: Salmo 42 - Como busca la cierva}\n{artist: Belén Raigal, nsc}\n{key: Em}\n{capo: 2}\n\n{comment: Intro: mim | DO | lam | RE x2}\n\n[Em]COMO BUSCA LA CIERVA CORRIENTES DE AGUA, [C]ASÍ MI ALMA TE [Em]BUSCA (BIS) TIENE [C]SED DE TI MI [Em]ALMA, TIENE [C]SED DEL DIOS [B7]VIVO. [C]¿CUÁNDO PODRÉ EN[D]TRAR A [G]VER EL ROSTRO DE [B7]DIOS? \n\n1. [Am]Yo lo recuerdo den[D]tro de mi alma, [G]cómo marchaba a la [Em]tienda, [Am]cómo a la casa de [D]Dios [G]entre el gentío en [B7]fiesta. [Am]Espera en Dios, alma [D]mía espera, [G]nunca te canses que [Em]lo alabarás, [C]aunque en el fondo te [D]digan ¿[G]dónde está tu [B7]Dios? \n\n2. [Am]Todas tus olas me [D]han arrollado,[G] toda tu fuerza es[Em]tá sobre mí, [Am]aunque en el fondo a[D]ún me repiten ¿[G]dónde está tu [B7]Dios? [Am]En la mañana re[D]cibo tu Gracia [G]y por la noche te [Em]canto Señor, [C]eres el Dios de mi [D]vida, mi [G]roca y salva[B7]ción.\n"
+      },
+      {
+        "title": "20. Vuelve - Lc 15",
+        "filename": "20.lc15_vuelve.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "D",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Vuelve - Lc 15}\n{artist: Nati Escudero, nsc}\n{key: D}\n{capo: 2}\n\n1. [D]Llevo [F#m]tiempo espe[G]rándo[A]te, [D]con mis [F#m]brazos [G]abier[A]tos, \n[D]la espe[F#m]ranza me acom[G]paña y siempre es[Em]pero tu vuelta cada ma[A]ñana.\n[D]Hijo mío [F#m]Yo con[G]fío en [A]ti, [D]entra en [F#m]ti mismo y des[G]cubre la verdad [Em]del Amor que nos [A]tiene unidos.\n\n{soc}\n[D]VUELVE, [G]VUELVE A LA [A]VIDA, [D]VUELVE Y NO TE [G]SIENTAS PERDI[A]DO, [G]VEN A LA CASA DE TU [D]PADRE  Y [G]QUÉDA[A]TE CON[D]MIGO (BIS).\n{eoc}\n\n2. [D]Sólo de[F#m]seo que vu[G]el[A]vas, [D]lo dejes to[F#m]do y [G]ven[A]gas. [D]Yo nece[F#m]sito de [G]ti, a pe[Em]sar de tus fallos. \n¿[G]Qué  padre no perdona a su hijo a[A]mado? \n[D]Yo[F#m] te [G]acogeré, [A]te amaré, [D]pero [F#m]vuelve a mí tu [G]cora[A]zón, [D]y de a[F#m]mor y de ale[G]gría, [Em]Yo lo llena[A]ré.\n\n{soc}\n[D]VUELVE, [G]VUELVE A LA [A]VIDA, [D]VUELVE Y NO TE [G]SIENTAS PERDI[A]DO, [G]VEN A LA CASA DE TU [D]PADRE  Y [G]QUÉDA[A]TE CON[D]MIGO (BIS).\n{eoc}\n"
+      },
+      {
+        "title": "21. Shema Israel - Os 11",
+        "filename": "21.shema_israel.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "A",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Shema Israel - Os 11}\n{artist: Nati Escudero, nsc}\n{key: A}\n\n1. [A] Cuando era [F#m]niño yo te a[C#m]mé, te cui[D]dé e hijo [E]mío te [A]llamé[E].[A] Con cuerdas [F#m]dulces te lle[C#m]vaba, con lazos de a[D]mor y [E]ternura te cui[A]dé[E].\n[A] Yo te enseñé a cami[C#m]nar,[D]  yo te llevaba entre mis [E]brazos. [A] Tú te alzabas hasta [C#m]mí y [D]yo me inclinaba para seguirte a[E]mando.\n\n{soc}\nSHE[A]MA ISRA[C#m]EL, ES[D]CUCHA MI VOZ, YO TE AMÉ, TE [C#m]AMO Y TE AMA[F#m]RÉ. MIS [D]ENTRAÑAS SE ESTRE[E]MECEN POR [A]TI[F#m], IN[F]CLINA TU [G]CORAZÓN A [A]MÍ. \n{eoc}\n\n2. [A] En el de[F#m]sierto te he encon[C#m]trado perdida en la [D]tierra ar[E]diente y [A]seca[E].[A] Tu cora[F#m]zón me olvi[C#m]dó, la cera y el [D]humo, eran [E]para otro [A]dios[E].[A] Mi amor y mi ver[C#m]dad, [D]siempre te mira[E]rán. She[A]ma Isra[C#m]el, que tu [D]Dios con misericordia te an[E]sía.\n\n{soc}\nSHE[A]MA ISRA[C#m]EL, ES[D]CUCHA MI VOZ, YO TE AMÉ, TE [C#m]AMO Y TE AMA[F#m]RÉ. MIS [D]ENTRAÑAS SE ESTRE[E]MECEN POR [A]TI[F#m], IN[F]CLINA TU [G]CORAZÓN A [A]MÍ. \n{eoc}\n"
+      }
+    ]
+  },
+  "aleluya": {
+    "categoryTitle": "D. Aleluya - Palabra 📖",
+    "songs": [
+      {
+        "title": "01. Aleluya Cantará",
+        "filename": "01.aleluya_cantara.cho",
+        "author": "Brotes de Olivo",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aleluya Cantará}\n{artist: Brotes de Olivo}\n{key: E}\n\n{comment: Intro: MI}\n{soc}\nALE[A]LUYA [B]CANTA[E]RÁ QUIEN PER[F#m]DIÓ LA [G#m7]ESPERAN[C#m]ZA \nY LA [A]TIERRA [B]SONREI[E]RÁ, ALE[c#m]LUUUUU[E]UUUU[E]YA.  \n{eoc}\n\n{comment: Ver versión completa como 'Aleluya de la Tierra' que inlcuye dos estrofas}\n"
+      },
+      {
+        "title": "02. Aleluya",
+        "filename": "02.nunca_dejare.cho",
+        "author": "Kairoi",
+        "key": "C",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Aleluya}\n{artist: Kairoi}\n{key: C}\n{capo: 2}\n\n{soc}\n[C]ALELU[em]YA, [F]ALELU[G]YA, [C]ALELU[em]YA, [F]A[G]LELU[C]YA    \n{eoc}\n\n[C]Nunca deja[G]ré de can[Am]tar, \n[F]que tú eres la [Dm]luz y el [G]amor  \n[C]Tu camino [G]quiero se[Am]guir, [F]no me dejes [Dm]solo Se[G]ñor.\n"
+      },
+      {
+        "title": "04. Aleluya estamos de suerte",
+        "filename": "04.aleluya_estamos_suerte.cho",
+        "author": "",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aleluya estamos de suerte}\n{artist: }\n{key: D}\n\nSa[D]bes que hoy estamos de [F#m]suerte porque \nnos grita f[G]uerte el Dios de la [A]vida \n E[D]s su amor que se hace Pa[F#m]labra \ny aunque te sepa a[G]marga, es nueva por [A]día \nD[G]éjate sorprend[Bm]er y [G]cántalo otra [A]vez\n\n\n\n{soc}\nA[D]LEEE[F#m]LUUUUYA, [G]ALEEEL[D]UUUYA, [G]ALELU[A]YA (ALELU[D]YA) (x2)\n{eoc}"
+      },
+      {
+        "title": "11. Habla Señor",
+        "filename": "11.habla_senor.cho",
+        "author": "Inmaculada Vírseda",
+        "key": "A",
+        "capo": 0,
+        "info": "",
+        "content": "\n{title: Habla Señor}\n{author: Inmaculada Vírseda}\n{key: A}\n{capo: 0}\n\n{soc}\n[A]Habla Se[C#m]ñor, que tu [D]siervo es[E]cucha [A]Habla Se[C#m]ñor, que tu [D]siervo es[B7]cucha. \n{eoc}\n\nMuéstra[F#m]me tu volun[C#m]tad, a tra[D]vés de la Pa[A]labra, quiero [Bm]conocerte [C#m]más, para a[D]marte [E]y se[A]guirte (bis)\n"
+      },
+      {
+        "title": "20. Aleluya · Todo el mundo debe saberlo",
+        "filename": "20.aleluya_todoelmundodebesaberlo.cho",
+        "author": "Genverde",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aleluya · Todo el mundo debe saberlo}\n{artist: Genverde}\n{key: G}\n\nAleluya, aleluya, aleluya,\naleluya, aleluya, aleluya.\n\n¿Con qué palabras diría\nque no es llanto que son lágrimas de alegría?\nYo lo he visto, me sonreía,\nestá vivo, era él.\n\nComo un susurro se oía,\nera su voz, me llamó «María».\nYo lo he visto, me sonreía,\nél estaba junto a mí.\n\nAleluya, aleluya, aleluya…\n\nÁngeles nos han hablado\ndelante del sepulcro abandonado:\n«El Señor ha resucitado,\nestá vivo, no está aquí».\n\nSin respiro por el camino\ngritando fuerte a todos que él está vivo,\ntodo el mundo debe saberlo:\nvive ahora, vive aquí.\n\nAleluya, aleluya, aleluya…\n\nAlba, presagio de un tiempo\nque renueva la vida del universo.\nTodo nos habla de eterno\nporque él resucitó.\n\nDejan sus llagas, su gloria,\nhuellas vivas dentro de nuestra historia,\nsignos de un amor que no muere,\nvive siempre, vive hoy.\n\nAleluya, aleluya, aleluya…"
+      },
+      {
+        "title": "30. Aleluya de la Tierra",
+        "filename": "30.aleluya_tierra.cho",
+        "author": "Brotes de Olivo",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aleluya de la Tierra}\n{artist: Brotes de Olivo}\n{key: E}\n{comment: Versión completa con estrofas}\n\n\n{comment: Intro: MI}\n\n[E]¿Quién quiere resuci[A]tar, a este [B]mundo que se [E]muere?\n[A]¿Quién cantará el al[B]eluya, de esa [A]nueva [B]luz que [E]viene?\n[E]¿Quién cuando mire la [A]tierra, y las [F#m]tragedias obs[G#7]erve,\n\nSentirá en su cora[C#m]zón, el [F#m]dolor de quien se [B]muere?\n¿Quién es capaz[A] de salvar, a este mundo [B]decadente,\nY man[F#m]tiene la espe[B]ranza de los muchos que la [A]pier[E]den?\n\n\n{soc}\n[E]EL QUE [A]SUFRE  [B7]MATA Y [E]MUERE, \nDESESPE[A]RA Y [B7]ENLOQ[E]UECE,\nY OTROS [A]SON ESPEC[B7]TADO[E]RES, [E]NO LO [A]SIEE[B7]EEEEN[E]TEN\n{eoc}\n\n¿Quién bajará de la cruz  a tanto Cristo sufriente mientras los hombres miramos impasivos, indolentes?\n\n¿Quién grita desde el silencio de un ser que a su Dios retiene, porque se hace palabra que sin hablar se le entiende?\n\n¿Quién se torna en Aleluya porque traduce la muerte  como el trigo que se pudre y de uno cientos vienen?\n\n{soc}\nALE[A]LUYA [B]CANTA[E]RÁ QUIEN PER[F#m]DIÓ LA [G#m7]ESPERAN[C#m]ZA \nY LA [A]TIERRA [B]SONREI[E]RÁ, ALE[c#m]LUUUUU[E]UUUU[E]YA.  \n{eoc}\n"
+      }
+    ]
+  },
+  "ofertorio": {
+    "categoryTitle": "E. Ofertorio 🤲",
+    "songs": [
+      {
+        "title": "02. Gratis",
+        "filename": "02.gratis.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Gratis}\n{artist: Inma Vírseda}\n{key: D}\n{capo: 2}\n\n[C]Siento la vida como [Em]un regalo, [F]que Tú me das cada [G]día.\n[C]Tú me lo has dado y a [Am]Ti te lo doy, [F]pongo mi vida en tus [G]manos.\n\n{soc}\n[C]TODO LO QUE TENGO [Bb]VIENE DE TI.\n[F]HE DE DAR GRATIS LO QUE [G]GRATIS RECIBO DE [C]TI, [Em]SEÑOR \n[F]HE DE DAR GRATIS LO QUE [G]GRATIS RECIBO DE [C]TI\n\n\n|| [C]SUBIDA [A7]DE TON[D]O ||\n{eoc}\n[D]Te ofrezco hoy junto al [F#m]pan y el vino, [G]mis dudas mis alegr[A]ías.\n[D]Conviértelos en tu [F#m]cuerpo y sangre, [G]yo quiero amar como [A]Tú.\n\n\n{soc}\n[D]TODO LO QUE TENGO [C]VIENE DE TI.\n[G]HE DE DAR GRATIS LO QUE [A]GRATIS RECIBO DE [D]TI, [F#m]SEÑOR \n[G]HE DE DAR GRATIS LO QUE [A]GRATIS RECIBO DE [D]TI\n{eoc}\n"
+      },
+      {
+        "title": "08. Encima del Altar",
+        "filename": "08.encima_altar.cho",
+        "author": "Ixcis",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Encima del Altar}\n{artist: Ixcis}\n{key: D}\n\n\n{soc}\n[D] Y AQUÍ ENCIMA DE[C]L ALTAR, [G]EL PAN Y EL VINO CUENTAN ESA ETERNA HISTORIA \n[D]  DE UN DIOS QUE SE H[C]IZO HOMBRE [G]PARA ENSE[D]ÑAR [G]CÓMO HAY QUE A[D]MAR\n[D] Y AQUÍ ENCIMA DE[C]L ALTAR, [G]EL PAN Y EL VINO CUENTAN ESA ETERNA HISTORIA \n[D]  Y DAN A[C]GUA AL SEDIENTO Y [G]HAMBRE AL QUE TIENE [D]PAN\nY H[C]AMBRE AL QUE TIENE [D]PAN, [G]Y HAMBRE AL QUE TIENE [A]PAN\n{eoc}\n\n\nY ten mi vida y h[D]az que sea[C]n mis días algo más que problemas,\n  que [G]sepa torearlos sin perder esa estela. \n[D]  Tu voz, lo m[C]ás impo[G]rtante p[D]ara so[G]brevivi[D]r, no parar de reír.\n\nY no olvidarme[D] del que hom[C]bre se hace si en su vida deshace\n l[G]a cruda realidad del que solo dedica \n[D] su ser a m[C]irar su o[G]mbligo sin[D] ver m[G]ás allá[D] de e[G]sa reali[A]dad, hay que caminaaaar\n\n\n\n{soc}\n[D] Y AQUÍ ENCIMA DE[C]L ALTAR, [G]EL PAN Y EL VINO CUENTAN ESA ETERNA HISTORIA \n[D]  DE UN DIOS QUE SE H[C]IZO HOMBRE [G]PARA ENSE[D]ÑAR [G]CÓMO HAY QUE A[D]MAR\n[D] Y AQUÍ ENCIMA DE[C]L ALTAR, [G]EL PAN Y EL VINO CUENTAN ESA ETERNA HISTORIA \n[D]  Y DAN A[C]GUA AL SEDIENTO Y [G]HAMBRE AL QUE TIENE [D]PAN\nY H[C]AMBRE AL QUE TIENE [D]PAN, [G]Y HAMBRE AL QUE TIENE [D]PAN\n{eoc}"
+      },
+      {
+        "title": "99. Te presentamos Vino y Pan",
+        "filename": "99.te_presentamos_vino_pan.cho",
+        "author": "Juan Antonio Espinosa",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Te presentamos Vino y Pan}\n{artist: Juan Antonio Espinosa}\n{info: Grandes Clásicos}\n{comment: Grandes Clásicos}\n{key: D}\n\n{soc}\n[D]te presen[Bm]tamos\nel [G]vino y el  [D]Pan,\nBen[G]dito [D]seas\npor [A7]siempre, Se[D]ñor (x2)\n{eoc}\n\nBen[D]dito [G]seas, Se[D]ñor\npor [G]este pan que nos [D]diste\n[G]Fruto de la tierra\ny del [Em]trabajo de los [A]hombre[A7]s\n\n\n{soc}\n[D]te presen[Bm]tamos\nel [G]vino y el  [D]Pan,\nBen[G]dito [D]seas\npor [A7]siempre, Se[D]ñor (x2)\n{eoc}"
+      }
+    ]
+  },
+  "santo": {
+    "categoryTitle": "F. Santo ✝️",
+    "songs": [
+      {
+        "title": "02. Santo Beatles",
+        "filename": "02.santo_beatles.cho",
+        "author": "Help - The Beatles",
+        "key": "C",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Santo Beatles}\n{artist: Help - The Beatles}\n{key: C}\n{capo: 1}\n\n\n{soc}\n[C]SANTO, SANTO, SANTO, SANTO, SANTO ES EL [Em]SEÑ[Am]OR. \nLLENOS ESTAN EL CIELO Y [F]TIERRA DE TU AM[C]OR\n{eoc}\n\n[G]Bendito el que viene en el [F]nombre, el que que [G]viene en el nombre del [F]Seño[G]r, del [C]Señor"
+      },
+      {
+        "title": "05. Santo - Cantad",
+        "filename": "05.santo_cantad.cho",
+        "author": "",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Santo - Cantad}\n{key: G}\n\nSanto, S[G]anto, es [D]el Señor, el [Em]Señor (bis)[C][D]\nLos cie[C]los y LA tierra, proclama[D]n tu gloria \n[C]Bendito el que viene, en tu nomb[D]re Señor. \n[Em]Cantad, [G]cantad, [D]hosanna, [Em]por los siglos[D]\n[G]Santo, Santo, es [D]el Seño[Em]r, el S[C]eñor, e[D]l Señor…[Em]"
+      },
+      {
+        "title": "06. Santo 'Guay'Guay'",
+        "filename": "06.santo_expresarte.cho",
+        "author": "Expresarte",
+        "key": "A",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Santo 'Guay'Guay'}\n{artist: Expresarte}\n{key: A}\n\n\n{soc}\nS[A]ANTO, S[D]ANTO, S[A]ANTO, E[D]S EL SEÑ[E]OR (2)\nSA[A]NTO ES EL SEÑOR DIOS DEL U[D]NIVERSO\nLLENOS C[A]IELO Y TIERRA DE SU G[D]LORIA ES[E]TÁN (2)\n{eoc}\n\n\nHO[F#m]SANNA, HO[C#m]SANNA, HOS[D]ANNA EN EL CI[E]ELO  (X2)\nE[A]S BEN[D]DITO  [A]  EL N[D]OMBRE DE DI[E]OS\nE[A]S BEN[D]DITO  [A]  EL N[D]OMBRE DE DI[E]OS\nE[A]S BENDITO AQ[D]UEL QUE VIENE\nANUN[A]CIANDO EL NOMBRE D[D]E MI SE[E]ÑOR (2)"
+      },
+      {
+        "title": "07. Santo",
+        "filename": "07.santo_tsnc.cho",
+        "author": "Tomad Señor Nuestro Canto",
+        "key": "G",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Santo}\n{artist: Tomad Señor Nuestro Canto}\n{key: G}\n{capo: 3}\n\n\n\n{soc}\n[G]SANTO SANTO SANTO, OO[D]OOH SANTO ES EL SEÑOR\nDIOS DEL UNIV[C]ERSO, [D]DIOS DEL UNI[G]VERSO [D](2)\n{eoc}\n\n[Em]Llenos están el cielo y tierra de su [D]gloria\nHosanna en el [C]cielooooo[D]o, hosanna en [G]cielooo[D]oo\n\n[Em]Bendito el que viene en nombre del se[D]ñor\nHosanna en el [C]cielooooo[D]o, hosanna en [G]cielooo[D]oo"
+      },
+      {
+        "title": "08. Santo Handel",
+        "filename": "08.santo_haendel.cho",
+        "author": "Versión Händel",
+        "key": "Am",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Santo Handel}\n{artist: Versión Händel}\n{key: Am}\n\n\n{soc}\nS[Am]ANT[Dm]OO,[G]  SAN[C]TOO,[Am] SANTO ES EL SE[Dm]ÑOR, \nDIOS DEL [E]UNI[Am]VERSO. \nL[Am]LENOS E[Dm]STÁN [G]EL CIELO Y LA [C]TIERRA, \nD[Am]E TU G[Dm]LORIA, HO[E]SANN[Am]A. \n{eoc}\n\n\n{soc}\nH[A7]OSA[Dm]NNA[G], HOS[C]AN[F]NA, H[Dm]OS[E]ANNA[Am] EN EL CIELO. X2\n{eoc}\n\n\n{soc}\nB[Am]ENDITO E[Dm]L QUE VI[G]ENE EN N[C]OMBR[Am]E DEL SE[Dm]ÑOR, \nH[Am]OSANA E[Dm]N EL C[E]IEL[Am]O HOSANNA. \n{eoc}\n\n\n{soc}\nH[A7]OSA[Dm]NNA[G], HOS[C]AN[F]NA, H[Dm]OS[E]ANNA[Am] EN EL CIELO. X2\n{eoc}"
+      }
+    ]
+  },
+  "padrenuestro": {
+    "categoryTitle": "G. Padrenuestro 👐",
+    "songs": [
+      {
+        "title": "01. Padrenuestro Gallego",
+        "filename": "01.padrenuestro_gallego.cho",
+        "author": "Grandes Clásicos",
+        "key": "G",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Padrenuestro Gallego}\n{artist: Grandes Clásicos}\n{key: G}\n{capo: 1}\n                             \nEn el [G]mar he oído hoy, Señor tu [Em]voz que me llamó\nY me pi[C]dió que me entre[Am]gara a mis her[D]manos.\nEsa [G]voz me transformó, mi vida en[Em]tera ya cambió\nY solo [C]pienso ahora [Am]Señor, en repe[D]tirte \n\nPADRE [G]NUESTRO, EN TI CREEMOS\nPADRE [Em]NUESTRO, TE OFRECEMOS\nPADRE [C]NUESTRO, NUESTRAS [Am]MANOS DE HER[D]MANOS\n\nCuando [G]vaya a otro lugar, tendré [Em]Señor que abandonar\nA mi fa[C]milia a mis a[Am]migos por se[D]guirte\nPero [G]sé que así algún día podré en[Em]señar tu verdad\nA mi her[C]mano y junto a [Am]Él, yo repe[D]tirte.\n"
+      }
+    ]
+  },
+  "paz": {
+    "categoryTitle": "H. Paz 🕊️",
+    "songs": [
+      {
+        "title": "01. El Mundo Está Esperando la Paz de Dios",
+        "filename": "01.mundo_esta_esperando.cho",
+        "author": "",
+        "key": "C",
+        "capo": 3,
+        "info": "",
+        "content": "{title: El Mundo Está Esperando la Paz de Dios}\n{artist: }\n{key: C}\n{capo: 3}\n\n\n{soc}\nEL MU[C]UUU NDO EST[F]Á ESPERANDO LA PA[C]Z DE DIOS (bis[F])\n{eoc}\nEns[Am]éñanos m[Em]aestro a c[F]onstruir el r[G]eino.  \nEns[Am]éñanos m[Em]aestro, e[F]nséñanos m[G]aestro.\n\n{soc}\nEL M[C]UUUU NDO ES[F]TÁ ESPERANDO LA P[C]AZ DE DIOS (bis[F])\n{eoc}"
+      },
+      {
+        "title": "03. Esta paz que hoy nos das",
+        "filename": "03.esta_paz_hoy_nos_das.cho",
+        "author": "Genverde",
+        "key": "A",
+        "capo": 4,
+        "info": "",
+        "content": "{title: Esta paz que hoy nos das}\n{artist: Genverde}\n{key: A}\n{capo: 4}\n\nEsta paz [A]que hoy nos das, viva siempre e[D]stará, en LA tie[F#m]rra como en el cielo.[E]\n[A]Esta paz que hoy nos das nunca nos dejar[D]a, dando vida a muchos c[C]orazones.[G][D][E]\n\n\n{soc}\n[D]CON TU PAZ IREMO[A]S POR [E]EL MUNDO, CON [F#m]TU PAZ NUEST[D]RA HE[A]REDAD.[E][F#m]\n[D]CON TU PAZ NACE [A]UN CAN[E]TO AL UNISONO, QUE [F#m]SE OYE YA EN TO[G]DA LA CIUDAD.[E]\n{eoc}\n\n[A]Esta paz que hoy nos das como luz guiara[D], alumbrando nue[F#m]stros senderos.[E]\n[A]Esta paz que hoy nos das, piedra [D]a piedra hará, LA gran casa de [A]todos[E].[A]\n\n\n{soc}\n[D]ES TU PAZ UNA HU[A]ELLA [E]EN LA HISTORIA, [F#m]ES TU PAZ S[D]IGNO [A]DE UNIDA[E]D.[F#m]\n[D]ES TU PAZ LA ESP[A]ERANZA [E]SIN LÍMITES QUE T[F#m]ODO PUEBLO EN TI [G]ENCONTRARA.[E]\n{eoc}\n\n[A]Esta paz que hoy nos das, piedra [D]a piedra hará, LA gran casa de [A]todos[E].[A]"
+      }
+    ]
+  },
+  "comunion": {
+    "categoryTitle": "I. Comunión 🎶",
+    "songs": [
+      {
+        "title": "01. Quiero",
+        "filename": "01.quiero.cho",
+        "author": "Alborada",
+        "key": "G",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Quiero}\n{artist: Alborada}\n{key: G}\n{capo: 3}\n\nQui[G]ero que c[Bm]ada día pen[C]séis más en [C]mí. [D] \nQui[G]ero que nadie ol[Bm]vide lo que yo os [C]dije [D] \nN[Em]unca ol[Bm]vidare,[C] lo que con vos[Cm]otros viví \nOs q[G]uiero y por [Bm]eso os d[C]igo que [C]yo… [D]    \n\n\n{soc}\nY[G]O SOY, [Bm]YO SOY, LA [C]VIDA Y LA VER[D]DAD\n[G]Y EL QUE [Bm]CREA EN MI, [C]NUNCA MORIR[D]Á (bis)[G] \n{eoc}\n\nQuiero, que en el amor nunca exista un final\nQuiero que busquéis siempre el camino de la verdad\nSé que no es fácil, pensar siempre en los demás\nOs quiero y por eso os digo que yo…\n\nQuiero que entre vosotros siempre este LA paz \nQuiero que al más odiado vosotros lo acojáis \nEspero que améis al mundo como yo lo ame \nOs quiero y por eso os digo que yo…"
+      },
+      {
+        "title": "02. Consolad",
+        "filename": "02.consolad_nati.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "C",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Consolad}\n{artist: Nati Escudero, nsc}\n{key: C}\n{capo: 3}\n\n{soc}\n[DO]In[FA]tro[DO]duc[FA]cción\n{eoc}\n\n[C]Conso[F]lad, [C][F] [C]conso[F]lad. \n[C]El Espíritu sigue suscitando[Em][Am]a través del tiempo [F]nuevos pro[G]fetas, [E]de un Dios que llene el [F]corazón de [C]amor y de luz a una [Dm]vida [G]nueva.\n[C]Es llamada a adentrarnos en el misterio, [Em][Am] a renovar nuestro [F]ser consola[G]ción, [E]a descubrir nuevos hori[Am]zontes [F]en nuestro servicio a Dios [Dm]y a los [G]hombres.\n\n{soc} \n[C]ES UN HOY, ES [F]UN MAÑANA, [C]ESPERANZA [F]Y CERTEZA, [C]ES UN DON, [F]UN COMPROMISO, [C]UN RETO, UNA PRO[G]MESA. (BIS)\nNUESTRO [F]SER [G]CONSOLA[C]CIÓN. \n{eoc}\n\n[DO]INS[FA]TRU[DO]MEN[FA]TAL\n\n[C]Amaremos nuestro carisma[Em][Am]dando la vida [F]sin limita[G]ción, [E]viviendo dentro de la [Am]Iglesia, [F]renovando cada día [Dm]nuestra con[G]sagración. [C]Es un proyecto a vivir, [Em][Am] es apertura, [F]es contempla[G]ción, [Am]es ha[E]cer sentir al [Am]mundo [F]la fuerza de un Dios que [Dm]es Consola[G]ción. \n\n{soc} \n[C]ES UN HOY, ES [F]UN MAÑANA, [C]ESPERANZA [F]Y CERTEZA, [C]ES UN DON, [F]UN COMPROMISO, [C]UN RETO, UNA PRO[G]MESA. (BIS)\nNUESTRO [F]SER [G]CONSOLA[C]CIÓN. \n\n[DO]INS[FA]TRU[DO]MEN[FA]TAL\n{eoc}\n [C]El Espíritu sigue suscitando…\n"
+      },
+      {
+        "title": "05. Consolad",
+        "filename": "05.consolad_marisa.cho",
+        "author": "Marisa Arrufat",
+        "key": "A",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Consolad}\n{artist: Marisa Arrufat}\n{key: A}\n{capo: 3}\n\n[A]Consolad a mi pueblo [C#m]dice el Señor, ha[Bm]blad al corazón del [E]hombre\nGri[Bm]tad que mi amor ha ve[C#m]ncido, preparad el camin[G]o, que viene tu reden[E]tor. \n\n\n{soc}\n[A]YO TE HE ELE[E]GIDO PARA AMAR, TE DOY MI [Bm]FUERZA Y [F#m]LUZ PARA GUIAR, [A]YO SOY CON[E]SUELO EN TU MIRAR, [G]GLORIA A [E]DIOS.\n{eoc}\n\n[A]Consolad a mi pueblo di[C#m]ce el Señor, sac[Bm]ad de la ceguera a mi [E]pueblo. \n[Bm]Yo he sellado con[C#m]tigo la alianza per[G]petua. Yo soy el único [E]Dios.\n\n\n{soc}\n[A]YO TE HE ELE[E]GIDO PARA AMAR, TE DOY MI [Bm]FUERZA Y [F#m]LUZ PARA GUIAR, [A]YO SOY CON[E]SUELO EN TU MIRAR, [G]GLORIA A [E]DIOS.\n{eoc}\n\n[A]Consolad a mi pueblo [C#m]dice el Señor, mos[Bm]tradles el camino de liber[E]tad\n[Bm]Yo os daré fuertes [C#m]alas, transformaré tus pi[G]sadas en sendas de eterni[E]dad.\n\n{soc}\n[A]YO TE HE ELE[E]GIDO PARA AMAR, TE DOY MI [Bm]FUERZA Y [F#m]LUZ PARA GUIAR, [A]YO SOY CON[E]SUELO EN TU MIRAR, [G]GLORIA A [E]DIOS.\n{eoc}"
+      },
+      {
+        "title": "10. Cada Vez Más",
+        "filename": "10.cada_vez_mas.cho",
+        "author": "Inma Vírseda",
+        "key": "G",
+        "capo": 4,
+        "info": "",
+        "content": "{title: Cada Vez Más}\n{artist: Inma Vírseda}\n{key: G}\n{capo: 4}\n\n[G]Con el corazón e[Am]n fiesta vengo a darte hoy las[C] gracias, n[D]o puedo Señor v[G]ivir sin ti.\n[G]Solo pido que me a[Am]yudes a fiarme totalm[C]ente, solo[D] Tú, solo Tú, e[C]res e[D]l centr[G]o de mi ser \n\n\n{soc}\nCADA VEZ [Am]MÁS [D]QUIERO SEGUIRTE [G]JESÚS, [G7] \nPARA CONSTRU[C]IR TU R[D]EINO DE AMOR EN LA [G]TIERRA.[G7] \nCADA DÍA M[C]ÁS SIE[D]NTO TU AMOR EN MI [G]VIDA[F#m],\nY A[Em]UN SIN VERTE A [C]VECES, TE Q[D]UIERO CADA DÍA M[G]ÁS.\n{eoc}\n\n[G]Solo en ti está mi fuente, s[Am]olo Tú eres mi camino, y s[C]olo tu a[D]mor me gu[G]iará \n[G]Apoyada  en  tu  palabra,  co[Am]mo  sierva  d[C]e  los  pobres[D],  como  Tú[C]  y  por [D] ti, desg[G]astare yo mi existir."
+      },
+      {
+        "title": "200. Pescador de Hombres",
+        "filename": "200.pescador_hombres.cho",
+        "author": "Cesáreo Gabaráin",
+        "key": "G",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Pescador de Hombres}\n{artist: Cesáreo Gabaráin}\n{key: G}\n{capo: 3}\n{info: Grandes Clásicos}\n{comment: Grandes Clásicos}\n\n1. [G]Tú [D] has venido a la o[Em]rilla\nno has bus[C]cado [Am]  ni a sabios ni a [D]ricos\ntan solo [G]quieres [D]  que yo te [Em]siga\n\n{soc}\nSe[C]ñor,[D] me has mirado a los [G]ojos[Em]   \nsonri[C]endo,[D] has dicho mi[ G]nombre,[G7]     \nen la ar[C]ena [D7] he dejado mi [G]barca[Em]   \njunto a [C]ti   [D] busacaré otro [G]mar.\n{eoc}\n\n2. [G] Tú [D] sabes bien lo que[Em]tengo,\nen mi ba[C]rca [Am]  no hay oro ni [D]espadas\ntan solo r[G]edes [D] y mi tra[Em]bajo\n\n{soc}\nSe[C]ñor,[D] me has mirado a los [G]ojos[Em]   \nsonri[C]endo,[D] has dicho mi[ G]nombre,[G7]     \nen la ar[C]ena [D7] he dejado mi [G]barca[Em]   \njunto a [C]ti   [D] busacaré otro [G]mar.\n{eoc}\n\n\n3. [G] Tú [D] necesitas mis [Em]manos\nMI[C] cansancio[Am]  que A otros[D]descanse\namor [G]que quiera[D] seguir am[Em]ando\n\n{soc}\nSe[C]ñor,[D] me has mirado a los [G]ojos[Em]   \nsonri[C]endo,[D] has dicho mi[ G]nombre,[G7]     \nen la ar[C]ena [D7] he dejado mi [G]barca[Em]   \njunto a [C]ti   [D] busacaré otro [G]mar.\n{eoc}\n\n4. [G] Tú [D]pescador de otro[Em]s lagos\nansia [C] eterna[Am]  de almas que [D]esperan\namigo[G] bueno[D] que sí me [Em]llamas.\n\n{soc}\nSe[C]ñor,[D] me has mirado a los [G]ojos[Em]   \nsonri[C]endo,[D] has dicho mi[ G]nombre,[G7]     \nen la ar[C]ena [D7] he dejado mi [G]barca[Em]   \njunto a [C]ti   [D] busacaré otro [G]mar.\n{eoc}"
+      },
+      {
+        "title": "23. Queda mucho reino por Construir",
+        "filename": "23.queda_mucho_reino.cho",
+        "author": "Inma Vírseda",
+        "key": "G",
+        "capo": 2,
+        "info": "",
+        "content": "S{title: Queda mucho reino por Construir}\n{artist: Inma Vírseda}\n{key: G}\n{capo: 2}\n{comment: TODO: ARREGLAR ACORDES}\n\nGracias [G]por la vida que hoy me das, es u[D]n regalo que vie[Em]ne de ti. [C]\n[G]Quiero devolverla a quien me LA [Am]dio, quiero dar [C]MI vida por ti como tú. [D]\n[G]Cuento con tu vida y con [D]tu luz, eres Di[Em]os de vida, Dios de los [C]pobres. \n[G]Queda mucho reino por co[Am]nstruir, queda mucha gen[C]te por consolar.[D]\n\n\n{soc}\n[C]Y SIEMPRE TE PREGUNTO QUE QUIERES DE MI,[D]\n [Bm]Y CADA DIA ME PONGO EN TUS MANO[Em]S\n[C]AQUÍ ME TIENES SEÑOR JESÚS PARA [D]CONSOLAR[G]\n{eoc}\n\n[G]Tú eres MI sentido y MI razón, D[D]ios que ama, que [Em]ríe y comprende. [C]\n[G]Mira MI pobreza y MI peq[Am]ueñez, Tú siempre compre[C]ndes MI corazón.[D]\n[G]Pienso en tanta gente que sufre [D]hoy, Tú estuvist[Em]e al lado de todos[C]\n[G]Queda mucho reino por co[Am]nstruir, queda mucha gen[C]te por consolar.[D]"
+      },
+      {
+        "title": "36. El amor no tiene fronteras",
+        "filename": "36. El amor no tiene fronteras.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 1,
+        "info": "",
+        "content": "{title: El amor no tiene fronteras}\n{artist: Inma Vírseda}\n{key: D}\n{capo: 1}\n{comment: A Mª Teresa González Justo}\n\n1. Sólo [D]sé que fuiste [G]Tú quien me lla[D]mó a ser instrumento [Em7]de Consola[A]ción, hoy te [G]doy mi sí de [A]nuevo aunque [F#m]sé de mi pe[Bm]cado, pues con[G]fío en Ti, Señor, que vas con[A]migo.\nNo se [D]puede amar a [G]Dios a quien no ve[D]mos, si no amamos al her[Em7]mano a quien [A]vemos; cuando [G]quiera yo me[A]dir cómo [F#m]va mi amor a [Bm]Dios mira[G]ré si amo a todos mis her[A]manos.\n\n{soc}\nEL A[D]MOOO[A]OOOR [Bm]NO TIENE FRON[G]TERAS, EL A[D]MOOO[G]OOOR NO TIENE FRON[A]TERAS. (BIS)\n{eoc}\n\n2. Cada [D]día siento [G]que Tú me lo [D]pides, que yo dé mi vida [Em7]por llevarte a [A]todos, con de[G]talles muy pe[A]queños y con [F#m]gestos muy hu[Bm]manos para [G]hacer feliz a quien está a mi [A]lado. \nPero [D]no podemos [G]dar si no te[D]nemos y por eso es nece[Em7]saria la ora[A]ción, para a[G]mar como Tú [A]amas, perdo[F#m]nar como Tú hi[Bm]ciste y sem[G]brar paz y alegría al cami[A]nar.\n\n{soc}\nEL A[D]MOOO[A]OOOR [Bm]NO TIENE FRON[G]TERAS, EL A[D]MOOO[G]OOOR NO TIENE FRON[A]TERAS. (BIS)\n{eoc}\n\n3. Como [D]Tú quiero estar [G]siempre dispo[D]nible y que todo el que me [Em7]busque a Ti te en[A]cuentre, porque [G]yo les dé mi [A]vida como [F#m]la darías [Bm]Tú y así [G]puedan darte gracias y se[A]guirte. \nHaz que [D]no pase de [G]largo ante mi her[D]mano y que sean para [Em7]mí los prefe[A]ridos, los en[G]fermos, los pe[A]queños, los que [F#m]sufren y los [Bm]pobres porque [G]Tú, Señor Jesús, vives en [A]ellos.\n\n{soc}\nEL A[D]MOOO[A]OOOR [Bm]NO TIENE FRON[G]TERAS, EL A[D]MOOO[G]OOOR NO TIENE FRON[A]TERAS. (BIS)\n{eoc}"
+      },
+      {
+        "title": "38. Un Sí contesta otro Sí",
+        "filename": "38. Un sí contesta a otro sí.cho",
+        "author": "Virginia Barea y María Garza",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Un Sí contesta otro Sí}\n{artist: Virginia Barea y María Garza}\n{key: D}\n{comment: 150 años fundación de la Congregación Hnas. de la Consolación}\n\n1. [G]Dando gracias al [A]sí de [Bm]tantas personas [G]que contestaron al [A]gran sí de Dios; [G]mirando la [A]realidad escu[Bm]charon el grito [G]de la humanidad [A]rota… \n\n{soc}\n[G]¡Un [A]grito de[Bm] Dios! [G]¡un grito de[A] Dios! [G]Súbete a un [A]alto monte a[Bm]legre mensajero de Si[G]ón, el futuro está[A] en ti, [G]en tus [A]manos está el[D] sí. \n\t\n[G]UN SÍ CON[A]TESTA A OTRO [Bm]SÍ, GRANDES DI[G]ÁLOGOS SE [A]OYEN POR ENCIMA DEL [D]MAR, DE [G]MUNDO A [A]MUNDO SÍ[D]... UN SÍ CONTESTA A OTRO[A] SÍ, [D]SÍ\n{eoc}\n\n2. [G]No basta decir[A] sí una [Bm]vez en la vida, [G]mantén tu sí reno[A]vado en el tiempo. [G]Quien tiene espe[A]ranza a[Bm]rriesga su vida, [G]se le ha dado una [A]vida nueva…\n\n{comment: Un grito de Dios...}\n\n3. [G]La mies es [A]mucha y [Bm]siempre seremos [G]pocos ante el descon[A]suelo del mundo. [G]Engendra en tu [A]ser la [Bm]vida del Reino. [G]Hoy en ti es posible el [A]sueño de Dios…\n\n{comment: Un grito de Dios...}\n"
+      },
+      {
+        "title": "55. No Temas - Is 43",
+        "filename": "55.no_temas_nati.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "G",
+        "capo": 3,
+        "info": "",
+        "content": "{title: No Temas - Is 43}\n{artist: Nati Escudero, nsc}\n{key: G}\n{capo: 3}\n\n{comment: Intro: SOL | DO | SOL | lam | RE | lam | RE | SOL | DO...}\n\n1. [G]Tu eres mi [D]sierva, mi ele[C]gida,[Am] en quien yo me com[D]plazco. [G] En ti he puesto mi Es[C]píritu,[B] yo que te llamé y [Em]te llamo,[C] eres va[Am]liosa para[G] mi yo te for[Em]mé, arran[Am]qué los cerrojos de tus [C]puertas y  te tomé de la [D]mano.\n\n{soc}\nNO [G]TEMAS NO [D]TEMAS [C] TE HE LLAMADO POR TU [D]NOMBRE. NO [G]TEMAS NO [D]TEMAS  SI ATRA[C]VIESAS LAS [B7]AGUAS[Em] YO ESTARÉ CON[C]TIGO,  SI [G]PASAS  POR EL [Em]FUEGO [C]NO TE QUEMA[D]RÁS.\nNO [G]TEMAS NO [D]TEMAS[C] TE HE LLAMADO POR TU [D]NOMBRE.  NO [G]TEMAS NO [D]TEMAS CAMINA[C]RÉ DELANTE DE [B7]TI Y EN [Em]MI HALLARÁS LA [C]FUERZA PARA EN [G]TODO[C], PARA EN [G]TODO[C], PARA EN [G]TODO, A[C]MAR [D]Y SER[G]VIR.\n{eoc}\n\n2. [G] Tu eres mi [D]sierva, mi ele[C]gida,[Am] en quien yo me com[D]plazco. [G] Yo soy quien te [C]habita, te recons[B]truyo y te le[Em]vanto.[C] Consuela a mi [G]pueblo,[C] háblales al [G]corazón, [Am]amales y diles que Yo [C]soy su Consola[D]ción.\n\n{soc}\nNO [G]TEMAS NO [D]TEMAS [C] TE HE LLAMADO POR TU [D]NOMBRE. NO [G]TEMAS NO [D]TEMAS  SI ATRA[C]VIESAS LAS [B7]AGUAS[Em] YO ESTARÉ CON[C]TIGO,  SI [G]PASAS  POR EL [Em]FUEGO [C]NO TE QUEMA[D]RÁS.\nNO [G]TEMAS NO [D]TEMAS[C] TE HE LLAMADO POR TU [D]NOMBRE.  NO [G]TEMAS NO [D]TEMAS CAMINA[C]RÉ DELANTE DE [B7]TI Y EN [Em]MI HALLARÁS LA [C]FUERZA\nPARA EN [G]TODO[C], PARA EN [G]TODO[C], PARA EN [G]TODO, A[C]MAR [D]Y SER[G]VIR.\n{eoc}\n"
+      },
+      {
+        "title": "83. Siempre en Ti",
+        "filename": "83.siempre_en_ti.cho",
+        "author": "Genverde",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Siempre en Ti}\n{artist: Genverde}\n{key: G}\n\n{soc}\nNos llamas, Señor,\nnos llenas de vida,\naquí nuestros corazones laten junto a ti.\nNos colmas de amor\ny con tu presencia\nla noche transformas en aurora, Señor.\nNos haces uno en ti,\nsiempre en ti.\n{eoc}\n\nTú nos llamas ante tu altar\ny nos muestras cómo amar de verdad.\nCuando me tropiezo al andar\ntú me tiendes la mano y yo vuelvo a caminar.\n\n{soc}\nNos llamas, Señor,\n{eoc}\n\nToma nuestras vidas Señor,\ntu palabra llega al corazón.\nQuiero con tus ojos mirar\ny creer que morir en ti es resucitar.\n\n{soc}\nNos llamas, Señor,\n{eoc}\n\n\nNos haces uno en ti,\nsiempre en ti.\n\nSiempre en ti."
+      },
+      {
+        "title": "90. Enciéndeme",
+        "filename": "90.enciendeme.cho",
+        "author": "Hakuna Group Music",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Enciéndeme}\n{artist: Hakuna Group Music}\n{key: E}\n\n[E]Hoy quiero, Señor, ponerlo [A]todo en tu presencia\n[C#m]Darme hasta gastarme conti[B]go y por Ti.\n[E]Hoy quiero, Señor, ponerlo [A]todo ante tu puerta\n[C#m]Para en todo amarte y ser[B]vir.\n\n{soc}\nEnciénde[E]me y déjame arder donde haga [A]falta,\nEnciénde[E]me y déjame ser tu [A]luz,\nY así po[E]der llevarte hasta todas las [A]almas,\nSaciar la [E]sed que tienes [B]Tú desde la [E]cruz.\n{eoc}\n\n[E]Hoy quisiera madre, poner [A]todo en tu presencia,\n[C#m]Darme hasta gastarme, decir[B]le que sí,\n[E]Hoy te pido madre, que de[A]jes mi puerta abierta,\n[C#m]Para en todo amarle y ser[B]vir"
+      },
+      {
+        "title": "91. Huracán",
+        "filename": "91.huracan.cho",
+        "author": "Hakuna Group Music",
+        "key": "G",
+        "capo": 5,
+        "info": "",
+        "content": "{title: Huracán}\n{artist: Hakuna Group Music}\n{key: G}\n{capo: 5}\n\n\n\n{soc}\n[G]INS[D]TRU[Em]MENT[C]AL\n{eoc}\n\n{comment: Estrofa 1}\n[G]Me he hecho tantas preg[D]untas \n[Em]intentando enten[C]der, \n[G]me he lanzado a busc[D]arte \nsin sa[Em]berte [C]ver.\n[G]Me he asomado al a[D]bismo,\n[Em]me he atrevido a saltar y c[D]aer. \n\n\n[G]INS[D]TRU[Em]MENT[C]AL (x1)\n\n{soc}\nY un hura[G]cán [D]romperá\nel [Em]cielo desde mi garg[C]anta \ngritándo[G]te “¿dónde está[D]s cuando me haces [Em]falta[C]?”\n{eoc}\n\n\n[G]INST[D]RUM[Em]ENTAL [C](x2)\n\n{comment: Estrofa 2}\nY me han dado respuestas pero no sé qué hacer,\nhe prometido seguirte sin entender.\nY hay un eco en lo hondo que me empuja hacia ti,\ny aunque sea sin sentirte te buscaré.\n\n{soc}\nY un hura[G]cán [D]romperá\nel [Em]cielo desde mi garg[C]anta \ngritándo[G]te “¿dónde está[D]s cuando me haces [Em]falta[C]?\"\"\n{eoc}\n\n{comment: Estrofa 3 - Chicos}\nEstoy aqu[G]í en el sil[Am]encio, estoy aq[Bm7]uí,\nen este v[C]iento, estoy aq[Em]uí,\nsoy este tr[D]ozo de [C]pan.\n\nEstoy aqu[G]í, en tu la[Am]mento, estoy aq[Bm7]uí,\nEm en est[C]e eco, estoy aq[Em]uí,\nsoy este tr[D]ozo de [C]pan.\n\n{soc}\n{comment: 2 estribillos normales}\nY un hura[G]cán [D]romperá\nel [Em]cielo desde mi garg[C]anta \ngritándo[G]te “¿dónde está[D]s cuando me haces [Em]falta[C]?”\n\nY un hura[G]cán [D]romperá\nel [Em]cielo desde mi garg[C]anta \ngritándote “¿dónde es[B7]tás cuando me haces [Em]falta?”\n\n{comment: Cambio acordes}\nY un hura[G]cán [Am]romperá\nel [Bm]cielo desde mi garg[C9]anta \ngritándo[Em]te “¿dónde estás cuando me haces f[C]alta?”\n\n{comment: Chicos: Estoy aquí, estoy aquí, estoy aquí, soy ese trozo de pan..}\n{eoc}\n{comment: Final}\nY tu hura[G]cán [Am]romperá\nel [Bm]cielo desde mi garg[C9]anta  \ngritándo[Em]me cuanto me [D]haces fal[G]ta"
+      }
+    ]
+  },
+  "salida": {
+    "categoryTitle": "J. Salida 👣",
+    "songs": [
+      {
+        "title": "01. Madre enséñame a vivir como tú",
+        "filename": "01. Madre enséñame a vivir como tú.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Madre enséñame a vivir como tú}\n{artist: Inma Vírseda}\n{key: D}\n{capo: 2}\n{comment: A María Rosa Molas}\n\n1. [D]Tu vida no se entiende [G]si no es por A[D]mooor [G](x2).\n[D]Tu vida no se entiende [G]si no es desde [A]Dios.... Te des[Bm]cubro hoy, [F#m]Madre, abis[G]mada en Dios por la [A]fe, con en[Bm]trañas de mi[F#m]sericordia, [G]transparentas a [A]Dios.\n\n{soc}\n[D]MADRE, ENSÉ[A]ÑAME A VIVIR COMO TÚ[Bm], QUIERO [G]SER CON[A]SOLACIÓN[D]. ENSÉÑAME [A]A SEGUIR A [G]CRISTO[A] (BIS)\n{eoc}\n\n2. [D]Tu vida no se entiende [G]sin fraterni[D]daaaad [G](x2). \nTu [D]vida no se entiende [G]sin comuni[A]dad. \nTe des[Bm]cubro hoy,  [F#]Madre, siempre o[G]rante y llena de ac[A]ción, inde[Bm]fensa pero [F#m]invencible, [G]vives y haces vi[A]vir.\n\n\n3. [D]Tu vida no se entiende [G]sin Consola[D]cióoon [G](x2). \nTú [D]vida no se entiende [G]sin la humil[A]dad. \nTe des[Bm]cubro hoy, [F#m]Madre, escon[G]dida con Cristo en [A]Dios, la Espe[Bm]ranza impulsa [F#m]tu vivir: [G]VIVES EN CARI[A]DAD. \n\n\n{soc}\n[D]MADRE, ENSÉ[A]ÑAME A VIVIR COMO TÚ[Bm], QUIERO [G]SER CON[A]SOLACIÓN[D]. ENSÉÑAME [A]A SEGUIR A [G]CRISTO[A] (BIS)\n\n{comment: +1 tono}\n[E]MADRE, ENSÉ[B]ÑAME A VIVIR COMO TÚ[C#m], QUIERO [A]SER CON[B]SOLACIÓN[E]. ENSÉÑAME [B]A SEGUIR A [A]CRISTO[B] (BIS)\n{eoc}"
+      },
+      {
+        "title": "01. Madre Enseñame a Vivir como Tú",
+        "filename": "01.madre_ensemae.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Madre Enseñame a Vivir como Tú}\n{artist: Inma Vírseda}\n{key: D}\n\nTu v[D]ida no sé entiend[G]e si no es po[D]r Amo[G]r (repite segunda voz)\nTu vi[D]da no sé entiende S[G]I no es desde D[A]ios  \nTe des[Bm]cubro hoy, M[F#m]adre, ab[G]ismada siempre en Dios por  l[A]a  fe, \n con ent[Bm]rañas de mise[F#m]ricordia, t[G]ransparentas a D[A]ios.\n\n\n{soc}\nM[D]ADRE, ENSÉÑ[A]AME A VIVIR COMO[Bm] TÚ, QUIERO S[G]ER CON[A]SOLACIÓ[D]N.\n ENSÉÑ[A]AME A SEGUIR A C[G]RIST[A]O (BIS)\n{eoc}\n\nTu v[D]ida no sé entiende s[G]in frater[D]nidad. [G] (repite segunda voz)\nTu vi[D]da no sé entiende s[G]in comunid[A]ad. \nTe des[Bm]cubro hoy, M[F#m]adre, siempre o[G]rante y llena de acc[A]ión,\n indefen[Bm]sa pero inven[F#m]cible, vive[G]s y haces vi[A]vir\n\n\n{soc}\nM[D]ADRE, ENSÉÑ[A]AME A VIVIR COMO[Bm] TÚ, QUIERO S[G]ER CON[A]SOLACIÓ[D]N.\n ENSÉÑ[A]AME A SEGUIR A C[G]RIST[A]O (BIS)\n{eoc}\n\nTu  v[D]ida  no  sé  entie[G]nde  sin  Con[D]solaci[G]ón.  \n\nTú  vida  no  sé  entiende  sin  la humildad\nTe des[Bm]cubro hoy, [F#m]madre, [G]escondida en Cristo en [A]Dios, \nLa esper[Bm]anza impulsa t[F#m]u vivir: VIV[G]ES EN CARIDAD[A].\n\n\n{soc}\nM[D]ADRE, ENSÉÑ[A]AME A VIVIR COMO[Bm] TÚ, QUIERO S[G]ER CON[A]SOLACIÓ[D]N.\n ENSÉÑ[A]AME A SEGUIR A C[G]RIST[A]O (BIS)\n{eoc}"
+      },
+      {
+        "title": "05. Llevad la buena noticia",
+        "filename": "05.llevad_buena_noticia.cho",
+        "author": "",
+        "key": "A",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Llevad la buena noticia}\n{artist: }\n{key: A}\n\n{soc}\nLleva[A]d la buena noticia a [D]todo ser que respira y \ndecid[A]les que la paz, es[E]tá dentro de sus vidas y que \n[A]ellos paz serán si despa[D]rraman amor\nA tod[A]os los hombres que encuentren, \npor e[E]sos caminos de Dios.\n{eoc}"
+      },
+      {
+        "title": "50. María de Nazaret",
+        "filename": "50.maria_de_nazaret.cho",
+        "author": "Consolación",
+        "key": "C",
+        "capo": 3,
+        "info": "",
+        "content": "{title: María de Nazaret}\n{artist: Consolación}\n{key: C}\n{capo: 3}\n\n\n{comment: \"INTRO: Do\"}\n{soc}\n[F]MARÍA [G]DE NAZA[Am]RET, [D]MARÍA MADRE DE [G]DIOS, [E]MARÍA MADRE [Am]NUESTRA, [F]MADRE [C]DE [G]CONSOLACI[C]ÓN\n{eoc}\n\nVives atenta al Señor, dejas tus planes por Él, como exclava de Dios, le dices SÍ en Nazaret.\n\nY así has hecho posible, que tomara carne en ti, Cristo el hijo de Dios, que es nuestra Consolación..."
+      },
+      {
+        "title": "51. Junto a ti María",
+        "filename": "51.junto_a_ti_maria.cho",
+        "author": "Grandes Clásicos",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Junto a ti María}\n{artist: Grandes Clásicos}\n{key: D}\n\n[D]Junto a ti Mar[A]ía,\nComo [Bm]niño quiero est[F#m]ar,\n[G]Tómame en tus m[D]anos,\nGuia[E]me en mi camin[A]ar.\n\n[D]Quiero que me ed[A]uques,\nQue me en[Bm]señes a o[F#m]rar,\n[G]Hazme transpar[D]ente,\nLlena[A]me de p[D]az[A7]\n\n{soc}\n[D]MAD[A]RE, [Bm]MADR[F#m]E,\n[G]MADR[D]E, M[E]ADR[A]E.\n{eoc}\n{soc}\n[D]MAD[A]RE, [Bm]MADR[F#m]E,\n[G]MADR[D]E, [G]MA[A]DRE[D].\n{eoc}\n\nGracias Madre mía, por llevarnos a Jesús,\nHaznos más humildes, tan sencillos como tú.\n\nGracias Madre mía, por abrir tu corazón,\nPorque nos congregas y nos das tu amor.\n\n{soc}\n[D]MAD[A]RE, [Bm]MADR[F#m]E,\n[G]MADR[D]E, M[E]ADR[A]E.\n{eoc}\n{soc}\n[D]MAD[A]RE, [Bm]MADR[F#m]E,\n[G]MADR[D]E, [G]MA[A]DRE[D].\n{eoc}"
+      }
+    ]
+  },
+  "himnos": {
+    "categoryTitle": "K. Himnos 🔝",
+    "songs": [
+      {
+        "title": "01. Somos Consolación",
+        "filename": "01. Somos Consolacion.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Somos Consolación}\n{artist: Inma Vírseda}\n{key: D}\n{comment: VI Congreso Internacional del COM · Tortosa · 2007}\n\n{comment: Intro: RE | SOL | RE | LA x2}\n\n1. [D]Nos reunimos a[A]quí de tantos lu[Bm]gares, tantos a[G]migos, [D]unidos por [A]un ideal: el Evan[G]gelio de Je[A]sús. [Bm]Unidos por [F#m]una experiencia vi[G]vida en el cora[D]zón: [G]Dios nos da[Em] su Consola[A]ción.\n\n{soc}\n[D]SOMOS CON[G]SOLA[D]CIÓN, LLEVAMOS LA ESPE[G]RANZA Y LA PAZ DE [A]DIOS. [D]SOMOS CON[G]SOLA[D]CIÓN, SEGUIMOS TRAS LAS [G]HUELLAS DEL SEÑOR JE[A]SÚS. QUEREMOS SER SUS [G]MANOS Y SU CORA[A]ZÓN EN MEDIO DE UN [F#m]MUNDO SEDIENTO DE A[G]MOR. ¡¡SOMOS, [D]SO[G]MOS, [D]SOMOS CON[A]SOLA[D]CIÓN[G]!!\n{comment: Instrumental: RE | SOL | RE | LA x2}\n{eoc}\n\n2. [D] Nos reunimos aquí[A] y recor[Bm]damos tantos mo[G]mentos [D]vividos en [A]grupos del COM, que ani[G]maron nuestra [A]fe. [Bm]Roma, Tor[F#m]tosa… y por todo el [G]mundo se extiende [D]ya [G]como una [Em]luz, la gente del [A]COM.\n\n{soc}\n[D]SOMOS CON[G]SOLA[D]CIÓN, LLEVAMOS LA ESPE[G]RANZA Y LA PAZ DE [A]DIOS. [D]SOMOS CON[G]SOLA[D]CIÓN, SEGUIMOS TRAS LAS [G]HUELLAS DEL SEÑOR JE[A]SÚS. QUEREMOS SER SUS [G]MANOS Y SU CORA[A]ZÓN EN MEDIO DE UN [F#m]MUNDO SEDIENTO DE A[G]MOR. ¡¡SOMOS, [D]SO[G]MOS, [D]SOMOS CON[A]SOLA[D]CIÓN[G]!!\n{comment: Instrumental: RE | SOL | RE | LA x2}\n{eoc}\n\n3. [D]Nos reunimos aquí[A] y hacemos pre[Bm]sente a Mª [G]Rosa, [D]aquella mujer[A] que vivió en la I[G]glesia para [A]Dios, [Bm]que sólo bus[F#m]có Consolar al que [G]sufre, en nombre de [D]Dios y [G]empezó un Ca[Em]risma que todos vi[A]vimos hoy.\n\n{soc}\n[D]SOMOS CON[G]SOLA[D]CIÓN, LLEVAMOS LA ESPE[G]RANZA Y LA PAZ DE [A]DIOS. [D]SOMOS CON[G]SOLA[D]CIÓN, SEGUIMOS TRAS LAS [G]HUELLAS DEL SEÑOR JE[A]SÚS. QUEREMOS SER SUS [G]MANOS Y SU CORA[A]ZÓN EN MEDIO DE UN [F#m]MUNDO SEDIENTO DE A[G]MOR. ¡¡SOMOS, [D]SO[G]MOS, [D]SOMOS CON[A]SOLA[D]CIÓN[G]!!\n{comment: Instrumental: RE | SOL | RE | LA x2}\n¡¡SOMOS, [D]SO[G]MOS, [D]SOMOS CON[A]SOLA[D]CIÓN[G]!!\n{eoc}"
+      },
+      {
+        "title": "02. Himno Delwende",
+        "filename": "02. Himno ONGD Delwende.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Himno Delwende}\n{artist: Inma Vírseda}\n{key: D}\n{comment: Himno ONGD Delwende: Al servicio de la Vida}\n\n1. No te[G]nemos en nuestras [D]manos la res[A]puesta al dolor del mundo. Pero [Bm]frente al dolor del [G]mundo, tenemos nuestras [A]manos. Cuando [G]Dios de la historia venga, [A]nos mirará las [Bm]manos, [G]nos mirará las [A]mano[Bm]s\n\n{soc}\n[Bm]Por un mundo [E]más humano [G]y un futuro [Bm]para los pueblos del Sur (bis)\nDELWEN[Bm]DEEE[E]EE,“AL SER[G]VICIO DE LA [Bm]VIDA”,   DELWEN[Bm]DEEE[E]EE “AL SER[G]VICIO DE LA [Bm]VIDA\" (bis)\n{eoc}\n\n[D]Como un signo de los tiempos [G]vive ya[A] DELWEN[D]DE, como cauce para ti de [G]solidaridad. [Bm]Para tender una [G]mano [A]a los hermanos más [D]pobres, luchar por su desa[G]rrollo y potenciar su ri[A]queza. [G]Es la me[A]jor inver[D]sión, al fi[G]nal de la vida, sólo el A[A]mor con[Bm]tará.\n\n{soc}\nDELWEN[Bm]DEEE[E]EE,“AL SER[G]VICIO DE LA [Bm]VIDA”,   DELWEN[Bm]DEEE[E]EE “AL SER[G]VICIO DE LA [Bm]VIDA\" (bis)\n{eoc}\n\n[D]Es un reto para todos [G]extender[A] DELWEN[D]DE una nueva cultura de [G]solidaridad, [Bm]defender siempre la [G]vida, [A]sembrando paz y jus[D]ticia, sin miedo a comprome[G]ternos para ayudar a vi[A]vir. [G]Si somos [A]CONSOLA[D]CIÓN, el ser[G]vir a quien sufre debe ser [A]hoy nuestra [Bm]opción."
+      },
+      {
+        "title": "03. Himno del COM",
+        "filename": "03. Himno del COM.cho",
+        "author": "Mª Dolores García",
+        "key": "Em",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Himno del COM}\n{author: Mª Dolores García}\n{key: Em}\n{capo: 1}\n\nEs[Em]toy viendo en [Am]torno a mí [D]gente que pasa va[G]cía, her[Am]manos que miran sin [Em]ver, he[B7]rmanos que sufren y [Em]lloran. Estoy viendo en [Am]torno a mí un [D]mundo sin espe[G]ranza, un [B7]mundo que no tiene [Em]paz, un [B7]mundo que no tiene a[Em]mor. \n\n{soc}\nY DIOS ME [Am]GRITA DESDE EL FONDO DE MI [Em]SER: ¡CONSO[B7]LAD A MI [Em]PUEBLO! Y DIOS ME [Am]GRITA DESDE EL FONDO DE MI [Em]SER: ¡[B7]CONSO[Em]LAD!\nTÚ PUEDES [Am]SER CONSOLA[Em]CIÓN, CONSOLA[B7]CIÓN PARA EL [Em]MUNDO. TÚ PUEDES [Am]SER CAMINO DE [Em]PAZ. TÚ PUEDES [B7]SER: ¡CONSOLA[Em]CIÓN!\n{eoc}\n\nSiento muy den[Am]tro de mí la ur[D]gencia de la Pa[G]labra: “[Am]Permaneced en mi a[Em]mor, ¡[B7]sed mensajeros del [Em]Reino! Os daré al Con[Am]solador, [D]nunca os dejaré [G]solos y en [B7]Él podréis comprar[Em]tir, y en [B7]Él podréis conso[Em]lar”. \n\n{soc}\nY DIOS ME [Am]GRITA DESDE EL FONDO DE MI [Em]SER: ¡CONSO[B7]LAD A MI [Em]PUEBLO! Y DIOS ME [Am]GRITA DESDE EL FONDO DE MI [Em]SER: ¡[B7]CONSO[Em]LAD!\nTÚ PUEDES [Am]SER CONSOLA[Em]CIÓN, CONSOLA[B7]CIÓN PARA EL [Em]MUNDO. TÚ PUEDES [Am]SER CAMINO DE [Em]PAZ. TÚ PUEDES [B7]SER: ¡CONSOLA[Em]CIÓN!\n\n¡CONSOLA[Am]CIÓN PARA EL [Em]MUNDO! ¡CONSOLA[B7]CIÓN [Em]HOY! ¡CONSOLA[Am]CIÓN PARA [Em]HOMBRE! ¡[B7]QUIERO [Em]SER! ¡[B7]QUIERO [Em]SER!\n{eoc}"
+      },
+      {
+        "title": "04. Cuenta Conmigo(Himno Samuel)",
+        "filename": "04. Cuenta conmigo.cho",
+        "author": "",
+        "key": "A",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Cuenta Conmigo(Himno Samuel)}\n{artist: }\n{key: A}\n{capo: 2}\n"
+      },
+      {
+        "title": "05. Rompe tus Cadenas",
+        "filename": "05. Rompe tus cadenas.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Rompe tus Cadenas}\n{artist: Inma Vírseda}\n{key: D}\n{capo: 1}\n{comment: V Congreso Internacional del COM · Zaragoza · 2004}\n\n{soc}\n[D]ROMPE TUS CA[C]DENAS, [G]VEN ARRIÉSGA[A]TE (BIS) A [G]SER CONSOLACIÓN, A LLE[Em]VAR A LA [A]PAZ DE DIOS.[D] (BIS)\n{eoc}\n\nPor ca[D]minos dife[C]rentes nos vol[G]vemos a encon[D]trar. Es Je[D]sús quien nos re[C]úne, quién nos [G]da la liber[A]tad para [G]dar su a[A]mor, su Evan[G]gelio de esper[E]anza y de [A]paz.\n\n{soc}\n[D]ROMPE TUS CA[C]DENAS, [G]VEN ARRIÉSGA[A]TE (BIS) A [G]SER CONSOLACIÓN, A LLE[Em]VAR A LA [A]PAZ DE DIOS.[D] (BIS)\n{eoc}\n\nSi Je[D]sús rompió ca[C]denas de quien [G]no contaba [D]ya, consolando, levan[C]tando, dando [G]vida a los de[A]más, dile [G]hoy que [A]sí, conti[G]núa su Evan[Em]gelio y su Mi[A]sión\n[D]Abre tus manos, [C]abre tus ojos, ¡[Em]muchos nece[A]sitan de ti! (bis)\n\n{soc}\n[D]ROMPE TUS CA[C]DENAS, [G]VEN ARRIÉSGA[A]TE (BIS) A [G]SER CONSOLACIÓN, A LLE[Em]VAR A LA [A]PAZ DE DIOS.[D]. [D]ROMPE TUS CA[C]DENAS, [G]VEN ARRIÉSGA[A]TE (BIS) A [G]SER CONSOLACIÓN, A LLE[Em]VAR A LA [A]PAZ DE DIOS.[D]   (SUBE [B]TONO)\n\n[E]ROMPE TUS CA[D]DENAS, [A]VEN ARRIÉSGA[B]TE (BIS) A [A]SER CONSOLACIÓN, A LLE[F#m]VAR A LA PAZ DE [B]DIOS. (BIS) [E]\n{eoc}"
+      },
+      {
+        "title": "06. Con cuerdas de ternura",
+        "filename": "06.con_cuerdas_de_ternura.cho",
+        "author": "Inma Vírseda",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Con cuerdas de ternura}\n{artist: Inma Vírseda}\n{key: G}\n\n[G]Cuántas cosas has hecho p[D]or mí, que s[Em]ería de mi sin ti [Bm]\n[C]Sólo tú pones un[G]a luz dentro de [D]mí. \n[G]Eres Dios, Padre nuestro de Amor, [D]\nnos regalas la  [Em]vida tú, la [Bm]alegría, [Am]la fe, el Amor, la li[G]bertad. [D]\n\n\n{soc}\n[G]CON CUERDAS DE TERNURA, CON CUE[D]RDAS DE TERNURA [Em][Bm]\n[C]TÚ ME AT[G]RAES HACIA TI JESÚS, ME ATRAES H[D]ACIA TI. \n[G]CON CUERDAS DE TERNURA, CON CUE[D]RDAS DE TERNURA [Em][Bm]\n [C]NADIE PUEDE NI PODR[G]Á SEPARA[C]RME DE T[D]U AMOR.[G][DO-RE][G][DO-RE]\n{eoc}\n\n\tVas conmigo Jesús, junto a mí, en lo bueno y en el dolor. \n        Aun si caigo tú estás allí con tu perdón. \n        Aunque sabes, Señor, como soy tu me llamas a Consolar. \n        Hoy te digo que sí, mi Dios, te seguiré."
+      },
+      {
+        "title": "08. Somos Jóvenes del COM",
+        "filename": "08. Jóvenes del COM.cho",
+        "author": "Inma Vírseda",
+        "key": "D",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Somos Jóvenes del COM}\n{artist: Inma Vírseda}\n{key: D}\n{capo: 1}\n{comment: III Congreso Internacional del COM · Tortosa y Reus · 1996}\n\n1. [D]La familia con[A]solación, reci[Bm]bimos la antorcha de [G]nuestro ca[A]risma. [D]En la Iglesia, que[A]remos vivir, reali[Bm]zando en el mundo [G]el Evan[A]gelio.[D] Nos llamó Je[A]sús el Señor para [G]se[A]r,[Bm] esperanza, [G]vida y fra[A]tern[D]idad.\n\n{soc}\nSOMOS [G]JÓVE[A]NES DEL [D]COM, ENVI[E]ADOS A CONSO[F#]LAR, SOMOS AN[G]TORCHA[A] DE [D]DIOS [F#]PARA EL 20[Bm]00. (BIS)\n{eoc}\n\n2. [D]El silencio [A]y la oración, nos con[Bm]forman con Cristo [G]Consola[A]dor[D] y nos lanzan [A]a Consolar, desgas[Bm]tando la vida [G]como la [A]Madre.[D] Viviremos [A]en libertad para [G]da[A]r[Bm] nuestra antorcha [G]a los que[A] sufren [D]hoy.\n\n3. [D]El Carisma [A]crece también y se ex[Bm]tiende en el tiempo [G]y en el es[A]pacio.[D]  Somos todo [A]un eslabón de esta in[Bm]mensa familia [G]univer[A]sal,[D] para amar a [A]Cristo Jesús, para [G]se[A]r[Bm] de los pobres [G]siervos por [A]el a[D]mor.\n\n{soc}\nSOMOS [G]JÓVE[A]NES DEL [D]COM, ENVI[E]ADOS A CONSO[F#]LAR, SOMOS AN[G]TORCHA[A] DE [D]DIOS [F#]PARA EL 20[Bm]00. (BIS)  \n[G]COM ANTORCHA DE [D]DIOS [F#]PARA EL 20[Bm]00\n{eoc}"
+      },
+      {
+        "title": "09. Testigos de la Palabra",
+        "filename": "09. Testigos de la Palabra.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "A",
+        "capo": 1,
+        "info": "",
+        "content": "{title: Testigos de la Palabra}\n{artist: Nati Escudero, nsc}\n{key: A}\n{capo: 1}\n{comment: IV Congreso Internacional del COM, JMJ y Jubileo · Roma · 1996}\n\n1. [A]2000 a[D]ños de his[E]toria,[A] levantando a [D]la humani[E]dad,[F#m] Cristo ayer, [C#m]hoy y siempre con no[D]sotros esta[E]rá. [A]Abrid puertas [D]y ven[E]tanas, [A]dilatad el [D]hori[E]zonte, [F#m]vivid el [C#m]Evangelio y lle[D]vad su noticia a to[E]dos los hombres y sed...\n\n{soc}\nTES[A]TIGOS DE [D]LA PA[E]LABRA, TES[A]TIGOS DE [D]LA VER[E]DAD SOMOS [F#m]JÓVENES DEL [C#m]COM, LLA[D]MADOS A CONSO[E]LAR. Y SER…  TES[A]TIGOS DE [D]LA PA[E]LABRA, TES[A]TIGOS DE [D]LA VER[E]DAD SOMOS [F#m]JÓVENES DEL [C#m]COM, LLA[D]MADOS A CONSO[E]LAR.\n{eoc}\n\n2. [A]En este a[D]ño de [E]gracia,[A] vivamos la fra[D]terni[E]dad universal [F#m]y con júbi[C#m]lo cantemos,[D] porque es tiempo de jus[E]ticia y paz. [A]Unidos a [D]toda la I[E]glesia, [A]nos ponemos [D]en ca[E]mino, [F#m]haciendo del Carisma [C#m]nuestra vida y [D]junto con la Madre [E]ser peregrinos y ser…\n\n{soc}\nTES[A]TIGOS DE [D]LA PA[E]LABRA, TES[A]TIGOS DE [D]LA VER[E]DAD SOMOS [F#m]JÓVENES DEL [C#m]COM, LLA[D]MADOS A CONSO[E]LAR. Y SER…  TES[A]TIGOS DE [D]LA PA[E]LABRA, TES[A]TIGOS DE [D]LA VER[E]DAD SOMOS [F#m]JÓVENES DEL [C#m]COM, LLA[D]MADOS A CONSO[E]LAR.\n{eoc}"
+      },
+      {
+        "title": "10. Eres tu",
+        "filename": "10. Eres Tú.cho",
+        "author": "Esperanza Casaus, nsc",
+        "key": "C",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Eres tu}\n{artist: Esperanza Casaus, nsc}\n{key: C}\n\n\n{soc}\n[C]ERES [F]TÚ VIVES HOY [C]ROSA MOLA[F]S ERES [G]TU[C]\n{eoc}\n\nMu[F]jer de otro sigl[C]o mujer [E]que vives hoy, por[Am]que tu vi[F]da estuvo anc[C]lada si[F]empre [G]en Dios[C]\nAm[F]aste a los hermano[C]s sufris[E]te su dolor [Am]y partiste [F]con ellos tu [C]pan tu l[F]uz tu a[G]mor[C]\n\n\n{soc}\nERES [F]TÚ VIVES HOY [C]ROSA MOLA[F]S ERES [G]TU[C]\n{eoc}\n\nRe[F]gazo para el niño [C]que no g[E]ozo de amor, [Am]compañía al [F]anciano que [C]solo se [F]quedo[G][C]\nCa[F]mino de las vida[C]s que están [E]en formación, [Am]impuls[F]o para el jove[C]n que solo [F]busc[G]a amor[C]\n\n\n{soc}\nERES [F]TÚ VIVES HOY [C]ROSA MOLA[F]S ERES [G]TU[C]\n{eoc}\n\nDel [F]pobre inseparabl[C]e con el p[E]artes tu pan, [Am]llevas [F]en tus entraña[C]s volcán [F]de cari[G]dad[C]\nPa[F]ra tus hijas Madr[C]e, hija f[E]iel para Dios[Am], para e[F]l necesitado sie[C]mpre Cons[F]olación[G][C]\n\n\n{soc}\nERES [F]TÚ VIVES HOY [C]ROSA MOLA[F]S ERES [G]TU[C]\n{eoc}"
+      },
+      {
+        "title": "11. Haciendo Camino",
+        "filename": "11. Haciendo Camino.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "Am",
+        "capo": 3,
+        "info": "",
+        "content": "{title: Haciendo Camino}\n{artist: Nati Escudero, nsc}\n{key: Am}\n{capo: 3}\n{comment: I Ruta de la Madre · Tortosa a Reus}\n\n[Am]Abriendo ca[Em]mino hacia [F]nuevos hori[G]zontes, [Am]deja que el Es[Em]píritu ca[F]mine conti[G]go y te a[Am]dentrarás en ti[Em]erra nueva, [F]bajo un cielo [G]nuevo, [Am]caminando sobre las [Em]huellas, [F]de una mujer que descubrió, que descubrió, senderos de vida y consolación[G].\n\n{soc}\n[Am]HACIENDO CA[Em]MINO TRAS EL [F]ECO DE SUS [G]HUELLAS, [Am]TESTIMONIO [Em]VIVO DE [F]DIOS HECHO EXPE[G]RIENCIA. [Am]SAL DE TU [Em]TIERRA Y VIVE LA [F]FUERZA DEL [G]AMOR, [F]QUE DENTRO DE TI QUIERE SER CONSOLACI[C]ÓN. (BIS)\n{eoc}\n\n[Am]Apoyados en la [Em]Palabra y [F]mirando [G]siempre en Cristo, [Am]confiando en el [Em]Padre y [F]como pere[G]grinos, [Am]al igual que [Em]Mª Rosa [F]compartimos fe y fraternidad, siendo Iglesia viva y con nuestra vida a Dios en todo alabar[G]…\n\n{soc}\n[Am]HACIENDO CA[Em]MINO TRAS EL [F]ECO DE SUS [G]HUELLAS, [Am]TESTIMONIO [Em]VIVO DE [F]DIOS HECHO EXPE[G]RIENCIA. [Am]SAL DE TU [Em]TIERRA Y VIVE LA [F]FUERZA DEL [G]AMOR, [F]QUE DENTRO DE TI QUIERE SER CONSOLACI[C]ÓN. (BIS)\n{eoc}"
+      },
+      {
+        "title": "20. Firmes en la fe para Consolar",
+        "filename": "20. Firmes en la fe para consolar.cho",
+        "author": "Nati Escudero, nsc",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Firmes en la fe para Consolar}\n{artist: Nati Escudero, nsc}\n{key: E}\n{comment: VII Congreso Internacional del COM y JMJ · Madrid · 2011}\n\n[E]De nuevo en ca[B]mino[C#m]  sedientos de encon[G#m]trarte,[A] Tú que nos has lla[E]mado [A]y nos has hecho a tu i[B]magen.[E] Abrid de nuevo el [B]corazón,[C#m] vivid con fuerza la [G#m]comunión.[A] Construid el [E]Reino sien[A]do testigos [B]de su amor.\n\n{soc}\nFIRMES EN LA FE[E] Y ENRAI[A]ZADOS EN[B] TI. FIRMES EN LA FE[E] Y APO[A]YADOS EN TU PA[B]LABRA, QUE[A]REMOS SER TU LUZ[Bm], TU PAZ, TU [G#m]VIDA Y TU VER[C#m]DAD, ¡HA[A]BLAD AL CORAZÓN DEL HOMBRE Y [Bm]CONSOLAD! \nFIRMES EN LA FE[E] Y ENRAI[A]ZADOS EN[Bm] TI. FIRMES EN LA FE[E] Y APO[A]YADOS EN TU PA[B]LABRA. [A]SACIA NUESTRA SED, SÓLO EN [B]TI QUEREMOS SER Y VIVIR, FIRMES EN LA FE.\n{eoc}\n\n[E]Nos llamas a [Bm]Consolar,[C#m] al amor hecho [G#m]gratuidad,[A] a ser testigos de [E]tu Palabra[A] en horizontes de [B]sequedad.[E] Fecunda nuestra tie[B]rra,[C#m] haznos fuertes en [G#m]la debilidad,[A] somos Iglesia [E]viva que al [E]mundo quiere [B]consolar.\n\n{soc}\nFIRMES EN LA FE[E] Y ENRAI[A]ZADOS EN[B] TI. FIRMES EN LA FE[E] Y APO[A]YADOS EN TU PA[B]LABRA, QUE[A]REMOS SER TU LUZ[Bm], TU PAZ, TU [G#m]VIDA Y TU VER[C#m]DAD, ¡HA[A]BLAD AL CORAZÓN DEL HOMBRE Y [Bm]CONSOLAD! \nFIRMES EN LA FE[E] Y ENRAI[A]ZADOS EN[Bm] TI. FIRMES EN LA FE[E] Y APO[A]YADOS EN TU PA[B]LABRA. [A]SACIA NUESTRA SED, SÓLO EN [B]TI QUEREMOS SER Y VIVIR, FIRMES EN LA FE.\n{eoc}"
+      }
+    ]
+  },
+  "adoracion": {
+    "categoryTitle": "X. Adoración 🧎",
+    "songs": [
+      {
+        "title": "01. A ti te Alabo",
+        "filename": "01.a_ti_te_alaboo.cho",
+        "author": "Hakuna",
+        "key": "C",
+        "capo": 0,
+        "info": "",
+        "content": "{title: A ti te Alabo}\n{artist: Hakuna}\n{key: C}\n\n{soc}\nA ti te al[C]abo Señor en tu templo\nA ti te al[G]abo con todo el firmamento\n\nA ti t[Am]e alabo por todo lo que tú has hecho\nA ti te a[F]labo por crear sin merecerlo\nA ti te a[C]labo con trompas y flautas\nA ti te ala[G]bo con tambores y danzas\nA ti te al[Am]aban criaturitas y animales\nA ti te ala[F]ban las montañas y los mares\nA ti te al[Am.]aaaaaaba[F]n\n{eoc}\n\n\n\n{comment: Estrofa 🎵}\n\n[Am]A ese Ser que creó es[G]te\nMundo por am[F]or\nNo lo e[G]ncontraba\n[Am]No creía que fuera posible\nEste [F]don, un Dios, todo lo que veo a mi\nAlred[Am]edor grita que aquí\nEstás y esconde mi [F]temor\n\nTodo lo que siente que alabe\nAl S[Am]eñor y grite bien fuer[G]te\n\n\n{comment: Estribillo}\n\n{soc}\nA ti te al[C]abo Señor en tu templo\nA ti te al[G]abo con todo el firmamento\n\nA ti t[Am]e alabo por todo lo que tú has hecho\nA ti te a[F]labo por crear sin merecerlo\nA ti te a[C]labo con trompas y flautas\nA ti te ala[G]bo con tambores y danzas\nA ti te al[Am]aban criaturitas y animales\nA ti te ala[F]ban las montañas y los mares\nA ti te al[Am.]aaaaaaba[F]n\n{eoc}\n\n{comment: Puente 🌉}\n\n\n[C]A ti te alabo aunque te escondas, aunque yo no pueda verte\nA ti t[G]e alabo que me salvas de la muerte\nA ti te alabo en el si[Am]lencio de un amor que ya no siente\nA ti te alabo eres mi [F]Dios, eres mi Vida eres mi Fuer[G]te\n[C]A ti te alabo en lo sencillo cotidiano, indiferente\nA ti te alab[F]o con el vivo que se escapa de la muerte\nA ti te ala[Em]bo con el muerto que te espera ansiadamente\nA ti te al[F]abo eres mi Dios, eres mi [G]Vida\n\n\n{comment: Estribillo}\n{soc}\n[C]A ti te alabo Señor en tu templo\nA ti te al[G]abo con todo el firmamento\n\nA ti t[Am]e alabo por todo lo que tú has hecho\nA ti te a[F]labo por crear sin merecerlo\nA ti te a[C]labo con trompas y flautas\nA ti te ala[G]bo con tambores y danzas\nA ti te al[Am]aban criaturitas y animales\nA ti te ala[F]ban las montañas y los mares\nA ti te al[Am.]aaaaaaba[F]n\n{eoc}"
+      },
+      {
+        "title": "02. (Tú) El único Rey",
+        "filename": "02.tu_unico_rey.cho",
+        "author": "Tuyo",
+        "key": "C",
+        "capo": 0,
+        "info": "",
+        "content": "{title: (Tú) El único Rey}\n{artist: Tuyo}\n{key: C}\n\n{soc}\n[C]Tú, el Único Rey [Am]que tiene que reinar\n[F]El Único Señor [G]al que voy a alab[C]ar\nHoy levanto el cora[Am]zón al que lo conquist[F]ó\nSimpleme[G]nte porque Tú eres Dio[C]s\n{eoc}\n\n[C]Quiero ponerte por encima de t[F]odo\nEn cada mome[Am]nto sentarte en el tro[G]no\nQue tu alaba[C]nza esté siempre en mi b[F]oca\nY reco[Am]nocer que Tú eres Di[G]os\nQue al[F]abarte a Ti, S[G]eñorSea sie[C]mpre l[G]o prim[Am]ero\n[F]Fijo mi mirada en el ci[G]elo\n\n[C]Tú, el [C7M]Único Rey[Am] que tiene que rei[F]nar\nEl Único Señor[G] al que voy a alaba[C]r\nHoy [C7M]levanto el coraz[Am]ón al que lo conquist[F]ó\nSimplement[G]e porque Tú eres Dios[C]\n\n\n( C )( F  Em  Dm  G )\n[C]INS[F]TRU[Em]MEN[Dm]TA[G]L \n\nY a [F]Ti, toda la ala[Em]banza\nTodo el po[Dm]der y el honor\nToda la gl[G]oria al Señor (X3)\n\n{soc}\n[C]Tú, el [C7M]Único Rey[Am] que tiene que rei[F]nar\nEl Único Señor[G] al que voy a alaba[C]r\nHoy [C7M]levanto el coraz[Am]ón al que lo conquist[F]ó\nSimplement[G]e porque Tú eres Dios[C]\n\n[C]Tú, el [C7M]Único Rey[Am] que tiene que rei[F]nar\nEl Único Señor[G] al que voy a alaba[C]r\nHoy [C7M]levanto el coraz[Am]ón al que lo conquist[F]ó\nSimplement[G]e porque Tú eres Dios\n{eoc}\n\n[C]O[C]UTR[Am]O - Ú[C]LTIMOS [Am]ACOR[C]DES"
+      }
+    ]
+  },
+  "estribillos": {
+    "categoryTitle": "Y. Estribillos 🎼",
+    "songs": [
+      {
+        "title": "03. Nada nos Separará",
+        "filename": "03.nada_nos_separara.cho",
+        "author": "Brotes de Olivo",
+        "key": "G",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Nada nos Separará}\n{artist: Brotes de Olivo}\n{key: G}\n{capo: 2}\n\n{soc}\n[G] Nada nos se[C]parará[G] \t [C] \n[G] Nada nos se[C]parará[G]      [C] \n[G] Nada nos [Bm]separar[Em]á\n[C] del a[D]mor de [G]Dios…\n{eoc}"
+      },
+      {
+        "title": "10. Ubi caritas",
+        "filename": "10.taize_ubi_caritas.cho",
+        "author": "Taizé",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ubi caritas}\n{artist: Taizé}\n{key: D}\n\n[D]Ubi [A]cari[Bm]tas et [G]a-[Em]a[A]mor,\n[D]ubi [A]cari[Bm]tas, [G]Deus [A]ibi [D]est. [A]"
+      },
+      {
+        "title": "30. Señor, que florezca tu justicia",
+        "filename": "30.taize_florezca_justicia.cho",
+        "author": "Taizé",
+        "key": "Em",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Señor, que florezca tu justicia}\n{artist: Taizé}\n{key: Em}\n\nSe[Em]ñor, que flo[C]rezca [D]Tu jus[Em]ticia\ny tu [Am]paz empape la [D]tierra.\nOh, [Em]Dios, que flo[D]rezca Tu jus[Em]ticia\ny se [C]llene nuestra [Am]vida de [B]Ti."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Resumen

- Corregir acorde inválido `[-]` en la palabra "Jesucristo" (estrofa 2)
- Convertir notación española `[RE]` → `[D]` y `[RE-LA]` → `[D][A]`
- Eliminar comentario `{comment: ACORDES POR ARREGLAR}` ya resuelto
- Regenerar `songs-v0.7.json` que ahora incluye la categoría **Gloria** correctamente

## Antes / Después

```
- Je[D]suc[-]ri[A]sto          →  Je[D]sucri[A]sto
- Hijo [RE]del[A]              →  Hijo [D]del[A]
- del [RE-LA]                  →  del [D][A]
```

https://claude.ai/code/session_01M8bXQW989N23Sni4tJuMzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8bXQW989N23Sni4tJuMzC)_