### PR TITLE
feat: añadir docx2chordpro.py — parser específico del Cantoral Castellón v2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ cython_debug/
 .DS_Store
 songs/.DS_Store
 songs/.DS_Store
+scripts/staging_docx2cho/

--- a/scripts/C. Admin Cantoral - MAC.command
+++ b/scripts/C. Admin Cantoral - MAC.command
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Cantoral Admin — launcher Mac/Linux
+set -e
+cd "$(dirname "$0")/.."
+
+echo
+echo "=== Cantoral Admin ==="
+echo
+echo "Instalando dependencias si hace falta..."
+python3 -m pip install --quiet --user flask pillow || python3 -m pip install --quiet flask pillow
+
+URL="http://127.0.0.1:8765/"
+echo
+echo "Abriendo navegador en $URL ..."
+(sleep 1.5 && (open "$URL" 2>/dev/null || xdg-open "$URL" 2>/dev/null || true)) &
+echo
+echo "Arrancando servidor (Ctrl+C para parar)..."
+exec python3 scripts/admin/server.py

--- a/scripts/C. Admin Cantoral - WINDOWS.bat
+++ b/scripts/C. Admin Cantoral - WINDOWS.bat
@@ -1,0 +1,21 @@
+@echo off
+chcp 65001 > nul
+title Cantoral Admin
+cd /d "%~dp0\.."
+echo.
+echo === Cantoral Admin ===
+echo.
+echo Instalando dependencias si hace falta...
+python -m pip install --quiet flask pillow
+if errorlevel 1 (
+    echo ERROR instalando dependencias. Asegurate de tener Python 3.10+ en el PATH.
+    pause
+    exit /b 1
+)
+echo.
+echo Abriendo navegador en http://127.0.0.1:8765/ ...
+start "" http://127.0.0.1:8765/
+echo.
+echo Arrancando servidor (Ctrl+C para parar)...
+python scripts\admin\server.py
+pause

--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -1,0 +1,87 @@
+# Cantoral Admin
+
+Mini app local (Flask + Alpine.js, sin build) para gestionar el cantoral.
+
+## Arrancarlo
+
+**Windows**: doble-click en `scripts/C. Admin Cantoral - WINDOWS.bat`
+**Mac/Linux**: doble-click en `scripts/C. Admin Cantoral - MAC.command`
+
+O a mano:
+```bash
+pip install flask pillow
+python scripts/admin/server.py
+# abre http://127.0.0.1:8765/
+```
+
+## Qué hace
+
+### Dashboard
+Contadores en vivo: cuántas canciones tienes en `/songs`, cuántas hay en el
+cantoral .docx, cuántas faltan, cuántas tienen `📝 TO DO` pendiente, cuántas
+son tuyas que no están en el cantoral.
+
+### Catálogo (📋)
+Tabla con todas las canciones del repo. Cada fila lleva badges:
+- ✅ existe en repo + en cantoral
+- ➕ solo en repo (canción manual que añadiste tú)
+- 📝 con TO DO pendiente de revisión
+
+Filtros: por categoría, por TO DO, por "solo manuales", buscador por título/autor.
+
+### Editor de canción
+Click en cualquier título → abre el editor con 3 pestañas:
+
+- **🎨 Visual** — render con acordes encima de cada letra. Arrastra los acordes
+  con el ratón para moverlos. Por defecto hace _snap_ al inicio de palabra más
+  cercano; mantén `Shift` al soltar para colocar carácter a carácter (pixel
+  perfect). Doble-click sobre un acorde para editarlo, `Supr` para borrarlo,
+  click derecho para borrar. Botón "+ Añadir acorde" → click en una letra para
+  insertar.
+- **📝 Raw** — el ChordPro crudo en un textarea. Para casos donde quieras
+  reorganizar líneas, mover bloques enteros, etc.
+- **👁 Preview** — render limpio (sin botones), como se verá en la app móvil.
+
+Panel lateral: title / artist / key / capo editables siempre visibles.
+Cualquier cambio se aplica al .cho al pulsar `💾 Guardar`. Se hace backup
+automático en `songs-backup-edits/<timestamp>/`.
+
+Si la canción se importó del cantoral lleva el comentario
+`{comment: TO DO: PENDIENTE REVISIÓN ACORDES}` y la badge 📝. Cuando termines
+de revisarla, pulsa `✓ Revisada` y la marca desaparece.
+
+### Importar del cantoral (📥)
+Lista las canciones del `.docx` que aún no están en el repo. Checkboxes para
+seleccionar, "Importar X seleccionadas" hace conversión + guarda con
+`{comment: TO DO: ...}` al principio. Las recién importadas aparecen marcadas
+con 📝 en el catálogo.
+
+Click en cualquier título → preview de la conversión _sin_ guardar todavía.
+
+### Reordenar (🔀)
+Elige categoría, arrastra filas, "Aplicar nuevo orden" renombra los archivos
+`01.xxx.cho`, `02.yyy.cho`… con backup previo de la carpeta entera.
+
+### Regenerar songs.json
+Botón en el dashboard. Ejecuta `crear_songs_json.py` y muestra la salida.
+
+## TO DO marker
+
+Detectado por la regex `\bTO\s+DO\b` (con espacio entre TO y DO, para no
+confundir con el español "todo"). Cualquier `{comment: ...TO DO...}` cuenta.
+
+## Backups
+
+Cada edición / borrado / reordenación deja una copia en
+`songs-backup-edits/<timestamp>/`. La carpeta crece — borra contenido antiguo
+de vez en cuando.
+
+## Limitaciones conocidas
+
+- 9 canciones del docx tienen el cuerpo dentro de un text-box de Word
+  (drawing element). El parser las marca con warning y no genera acordes;
+  hay que hacerlas a mano usando el editor raw.
+- El matching difuso de títulos entre repo y docx puede equivocarse con
+  variantes (ej. "Hijos" vs "Hijas"). Si una canción aparece como _missing_
+  pero tú crees que ya está, comprueba los títulos en ambos sitios.
+- No hay autenticación. **No exponer fuera de localhost**.

--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -1,6 +1,7 @@
 # Cantoral Admin
 
-Mini app local (Flask + Alpine.js, sin build) para gestionar el cantoral.
+Mini app local (Flask + Alpine.js, sin build step) para gestionar el cantoral
+de la **Familia Consolación**.
 
 ## Arrancarlo
 
@@ -27,48 +28,102 @@ Tabla con todas las canciones del repo. Cada fila lleva badges:
 - ➕ solo en repo (canción manual que añadiste tú)
 - 📝 con TO DO pendiente de revisión
 
-Filtros: por categoría, por TO DO, por "solo manuales", buscador por título/autor.
+Filtros: por categoría, por TO DO, por "solo manuales", buscador.
 
 ### Editor de canción
-Click en cualquier título → abre el editor con 3 pestañas:
 
-- **🎨 Visual** — render con acordes encima de cada letra. Arrastra los acordes
-  con el ratón para moverlos. Por defecto hace _snap_ al inicio de palabra más
-  cercano; mantén `Shift` al soltar para colocar carácter a carácter (pixel
-  perfect). Doble-click sobre un acorde para editarlo, `Supr` para borrarlo,
-  click derecho para borrar. Botón "+ Añadir acorde" → click en una letra para
-  insertar.
-- **📝 Raw** — el ChordPro crudo en un textarea. Para casos donde quieras
-  reorganizar líneas, mover bloques enteros, etc.
-- **👁 Preview** — render limpio (sin botones), como se verá en la app móvil.
+Click en cualquier título → editor con 3 pestañas + panel lateral de metadatos.
 
-Panel lateral: title / artist / key / capo editables siempre visibles.
-Cualquier cambio se aplica al .cho al pulsar `💾 Guardar`. Se hace backup
-automático en `songs-backup-edits/<timestamp>/`.
+#### 🎨 Visual
+La pestaña principal de trabajo. Cada letra es un `<span>` independiente
+(preserva el ancho variable estilo Word) y los acordes flotan absolutamente
+encima centrados sobre la letra a la que apuntan.
 
-Si la canción se importó del cantoral lleva el comentario
-`{comment: TO DO: PENDIENTE REVISIÓN ACORDES}` y la badge 📝. Cuando termines
-de revisarla, pulsa `✓ Revisada` y la marca desaparece.
+**Drag de acordes** — al SOLTAR:
+| modificador  | comportamiento |
+| ------------ | -------------- |
+| (ninguno)    | snap al inicio de palabra más cercano |
+| `Shift`      | snap a inicio de **sílaba** (silabeado español) |
+| `Alt`        | sin snap, carácter a carácter (pixel-perfect) |
+
+**Edición de acordes**:
+- Doble-click sobre un acorde → prompt para cambiar texto (vacío = borrar).
+- Click derecho → borrar con confirmación.
+- `Supr` con acorde seleccionado → borrar.
+- Botón **"+ Acorde"** → activa modo añadir, click en una letra para insertar.
+
+**Edición de letra**:
+- Doble-click en la letra de una línea → prompt para editar el texto entero.
+  Los acordes intentan reubicarse en la misma palabra del nuevo texto.
+
+**Selección de líneas** (gutter izquierdo `○`):
+- Click en gutter → selecciona/desmarca línea.
+- `Shift`+click → selección de rango.
+- Líneas seleccionadas habilitan la toolbar de acciones.
+
+**Toolbar de acciones**:
+- 🟡 **Marcar estribillo** — envuelve la selección en `{soc}…{eoc}`.
+- **Quitar marca** — elimina los marcadores cercanos.
+- 📋 **Copiar acordes** — guarda en portapapeles el patrón de acordes de la
+  selección (con su letra original para mapear por palabra).
+- 📥 **Pegar acordes** — aplica el patrón a la selección actual, alineando
+  por _palabra_: acorde de la palabra N origen → palabra N destino. Después
+  solo hay que retocar a mano lo que haga falta.
+- 🔁 **Insertar estribillo** — pega un bloque `{soc}…{eoc}` ya existente
+  después de la selección.
+
+**Atajo de teclado**: `Ctrl/Cmd+S` guarda.
+
+#### 📝 Raw
+ChordPro crudo en textarea. Para reorganizar líneas grandes, mover bloques,
+añadir comentarios, etc. Sincroniza con el Visual al cambiar de pestaña.
+
+#### 👁 Preview
+Render limpio sin botones — como se verá en la app móvil. Los acordes salen
+en color sobre la letra, **sin corchetes**.
 
 ### Importar del cantoral (📥)
 Lista las canciones del `.docx` que aún no están en el repo. Checkboxes para
-seleccionar, "Importar X seleccionadas" hace conversión + guarda con
-`{comment: TO DO: ...}` al principio. Las recién importadas aparecen marcadas
-con 📝 en el catálogo.
-
-Click en cualquier título → preview de la conversión _sin_ guardar todavía.
+seleccionar, batch import añade `{comment: TO DO: PENDIENTE REVISIÓN ACORDES}`
+al principio. Aparecen marcadas con 📝 en el catálogo.
 
 ### Reordenar (🔀)
 Elige categoría, arrastra filas, "Aplicar nuevo orden" renombra los archivos
 `01.xxx.cho`, `02.yyy.cho`… con backup previo de la carpeta entera.
 
-### Regenerar songs.json
-Botón en el dashboard. Ejecuta `crear_songs_json.py` y muestra la salida.
+### Nueva canción a mano (➕)
+Botón en el dashboard. Modos:
+- **En blanco** — crea el .cho solo con cabecera y TO DO. Editas con el visual.
+- **Pegar ChordPro** — pegas el texto ya en formato `{title:...}\n[C]Letra...`.
+
+(En la lista hay dos modos más marcados como "próximamente": pegar formato
+Ultimate Guitar y pegar texto con acordes en línea de encima. Ver TAREAS_PENDIENTES.md.)
+
+## Guardado y publicación
+
+La app guarda directamente en los archivos `.cho`. Cuando termines de editar,
+en la terminal:
+
+```bash
+git add songs/
+git commit -m "..."
+git push
+```
+
+Un GitHub Action regenera `songs-vX.json` y lo sube a Firebase automáticamente.
+No necesitas regenerar el JSON tú.
+
+El indicador del topbar muestra el estado: `Sin cambios` / `● Sin guardar` /
+`Guardando…` / `✓ Guardado · haz commit cuando termines`.
 
 ## TO DO marker
 
-Detectado por la regex `\bTO\s+DO\b` (con espacio entre TO y DO, para no
-confundir con el español "todo"). Cualquier `{comment: ...TO DO...}` cuenta.
+Línea exacta añadida a las canciones recién importadas o creadas:
+`{comment: TO DO: PENDIENTE REVISIÓN ACORDES}`.
+
+La regex de detección es `\bTO\s+DO\b` (espacio entre TO y DO, así nunca
+confunde con la palabra española "todo"). Cuando termines de revisar una,
+pulsa **"✓ Revisada"** en el editor y se elimina la línea.
 
 ## Backups
 
@@ -78,10 +133,9 @@ de vez en cuando.
 
 ## Limitaciones conocidas
 
-- 9 canciones del docx tienen el cuerpo dentro de un text-box de Word
+- 9 canciones del docx (~4%) tienen el cuerpo dentro de un text box de Word
   (drawing element). El parser las marca con warning y no genera acordes;
-  hay que hacerlas a mano usando el editor raw.
+  hay que crearlas con "Nueva canción a mano".
 - El matching difuso de títulos entre repo y docx puede equivocarse con
-  variantes (ej. "Hijos" vs "Hijas"). Si una canción aparece como _missing_
-  pero tú crees que ya está, comprueba los títulos en ambos sitios.
+  variantes (ej. "Hijos" vs "Hijas").
 - No hay autenticación. **No exponer fuera de localhost**.

--- a/scripts/admin/TAREAS_PENDIENTES.md
+++ b/scripts/admin/TAREAS_PENDIENTES.md
@@ -1,0 +1,74 @@
+# Mejoras pendientes del admin
+
+Lista viva — añadir/quitar según se haga.
+
+## Importadores adicionales para "Nueva canción a mano"
+
+El modal de nueva canción tiene los modos `blank` y `chordpro` funcionando.
+Los siguientes están como placeholder (`disabled`):
+
+### Modo "Ultimate Guitar / formato tabulado monoespaciado"
+Texto pegado de UG, e-Chords, La Cuerda… donde los acordes están en líneas
+sobre la letra, alineados por posición de columna con fuente monoespaciada.
+
+Aprovechar el detector de `tab2chordpro.py` clásico, pero invocándolo desde el
+backend (sin prompts interactivos): aceptar el texto, ejecutar el conversor en
+memoria, devolver el .cho generado y abrirlo en el editor visual con TO DO.
+
+Punto de partida: copiar la lógica de `convert_lines` + `is_chord_line` +
+`inject` de `scripts/tab2chordpro.py` y exponerla como `POST /api/song/from-tabs`.
+
+### Modo "Texto con acordes en línea de encima (estilo Word)"
+Similar al anterior pero con espacios variables / tabs. Reusar el mismo
+parser que el modo Ultimate Guitar — la diferencia visual es solo cómo
+suele venir el texto. En realidad ambos modos pueden ser el mismo endpoint
+con la misma lógica de detección.
+
+## Mejoras del parser docx2chordpro.py
+
+- **Soporte de text boxes**: las 9 canciones que viven dentro de un
+  `<w:drawing>` quedan sin acordes. Se podría recorrer también el contenido
+  de `<wsp:txbx><w:txbxContent>` para extraerlas. Estructura: cada txbx
+  contiene `<w:p>` con runs y tabs igual que un párrafo normal.
+- **Tabla de mapeo acordes manual**: añadir un `scripts/chord_aliases.json`
+  con casos especiales del cantoral (acordes raros que el script no traduce
+  bien). Cargar en `translate_one_chord` antes del regex.
+- **Mejor detección de "música:"**: extraer la fila de "Música:" o "Letra:"
+  del docx cuando esté como párrafo aparte tras el título, para rellenar
+  `{artist}` automáticamente.
+
+## Editor visual
+
+- **Render con la fuente real del cantoral (Calibri)**: cargar Calibri
+  via @font-face o web font equivalente (Carlito es métricamente compatible
+  y libre). Mejoraría la fidelidad visual a Word.
+- **Undo/Redo** local en el editor visual (stack de estados).
+- **Atajo `+ acorde` directo con tecla**: hold de una tecla (`A`?) + click
+  para añadir sin tener que activar el modo en la toolbar.
+- **Indicador de palabra/sílaba** durante el drag: mostrar visualmente
+  dónde caerá el acorde antes de soltar (overlay sobre la letra target).
+- **Multiselección de acordes**: poder mover varios a la vez.
+- **Mapeo de acordes entre estrofas más inteligente**: cuando el número de
+  palabras difiere entre origen y destino, usar similaridad léxica
+  (Levenshtein) para alinear mejor.
+
+## Catálogo
+
+- **Vista compacta por categoría**: poder ver una categoría como tabla
+  estilo "índice" (número · título · key · capo · pendiente).
+- **Acción masiva**: seleccionar varias canciones del catálogo y
+  - mover de categoría
+  - aplicar/quitar TO DO en bloque
+  - exportar a un zip
+
+## Importar del cantoral
+
+- **Preview comparativo**: para canciones que ya están en repo, mostrar
+  diff entre la versión actual y la del cantoral para detectar
+  actualizaciones del docx que conviene incorporar.
+
+## Otros
+
+- **Test suite mínima** (pytest) para las funciones clave del parser:
+  `translate_one_chord`, `parse_chord_line`, snap-to-word, snap-to-syllable.
+- **Tema oscuro completo**: revisar contraste en el preview render.

--- a/scripts/admin/requirements.txt
+++ b/scripts/admin/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+pillow

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Admin local del Cantoral MCM.
+
+Servidor Flask que lee directamente el filesystem (no DB):
+  - /songs/<categoría>/*.cho   → canciones del repo
+  - /songs/indice.json         → orden y títulos amigables
+  - Cantoral Castellón v2.0.4.docx → fuente para importar
+
+Endpoints (ver /api/health para listado):
+  GET  /api/catalog                 → estado completo (categorías, canciones, status)
+  GET  /api/song?path=...           → contenido + metadata de un .cho
+  PUT  /api/song?path=...           → guarda contenido (body JSON: {content})
+  DELETE /api/song?path=...         → elimina archivo (con backup)
+  GET  /api/docx/list               → 225 canciones del docx con estado vs repo
+  GET  /api/docx/preview?id=N       → conversión sin guardar
+  POST /api/docx/import             → body: {ids: [N,...]} importa con TO DO
+  POST /api/reorder                 → body: {category, order: [filename,...]}
+  POST /api/build-json              → ejecuta crear_songs_json.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from flask import Flask, jsonify, request, send_from_directory, abort
+
+# Importar el conversor docx como módulo (mismo paquete scripts/)
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = SCRIPT_DIR.parent
+REPO_DIR = SCRIPTS_DIR.parent
+SONGS_DIR = REPO_DIR / "songs"
+BACKUP_DIR = REPO_DIR / "songs-backup-edits"
+INDICE_JSON = SONGS_DIR / "indice.json"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import docx2chordpro as d2c  # noqa: E402
+
+# Marca para canciones pendientes de revisar acordes (TO DO con espacio entre TO y DO)
+TODO_COMMENT_LINE = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
+TODO_REGEX = re.compile(r"\bTO\s+DO\b", re.IGNORECASE)
+
+app = Flask(__name__, static_folder=str(SCRIPT_DIR / "static"), static_url_path="")
+
+
+# ─────────── Utilidades ─────────── #
+
+def safe_relpath(path_str: str) -> Path:
+    """Convierte un path relativo del cliente a absoluto, validando que esté bajo /songs."""
+    p = (REPO_DIR / path_str).resolve()
+    try:
+        p.relative_to(SONGS_DIR.resolve())
+    except ValueError:
+        abort(400, "Path fuera de /songs")
+    return p
+
+
+def parse_cho_metadata(content: str) -> Dict[str, str]:
+    """Extrae metadata básica de un .cho."""
+    def get(key: str) -> str:
+        m = re.search(r"\{\s*" + key + r"\s*:\s*(.*?)\s*\}", content, re.IGNORECASE)
+        return m.group(1).strip() if m else ""
+
+    capo_raw = get("capo")
+    return {
+        "title": get("title"),
+        "artist": get("artist") or get("author"),
+        "key": get("key"),
+        "capo": int(capo_raw) if capo_raw.isdigit() else 0,
+        "has_todo": bool(TODO_REGEX.search(content)),
+    }
+
+
+def number_prefix(filename: str) -> Optional[int]:
+    m = re.match(r"(\d+)\.", filename)
+    return int(m.group(1)) if m else None
+
+
+def normalize_title_for_match(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s or "")
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    s = s.lower()
+    # Quitar paréntesis y su contenido (suelen ser autor)
+    s = re.sub(r"\([^)]*\)", " ", s)
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    return s.strip()
+
+
+def title_keys(s: str) -> List[str]:
+    """Devuelve varias variantes del título normalizadas para matching difuso."""
+    base = normalize_title_for_match(s)
+    keys = {base}
+    # quitar "c/N" final (info de cejilla en algunos títulos del docx)
+    keys.add(re.sub(r"\s+c\s+\d+\s*$", "", base).strip())
+    # primera palabra significativa eliminada (para casos como "el senor es...")
+    return [k for k in keys if k]
+
+
+def best_match(target_keys: List[str], index: Dict[str, "object"]) -> Optional["object"]:
+    for k in target_keys:
+        if k in index:
+            return index[k]
+    # Substring fallback
+    for tk in target_keys:
+        if not tk:
+            continue
+        for ik, v in index.items():
+            if tk in ik or ik in tk:
+                return v
+    return None
+
+
+def load_indice() -> Dict[str, dict]:
+    if INDICE_JSON.exists():
+        with open(INDICE_JSON, encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def list_categories() -> List[dict]:
+    """Devuelve lista de carpetas-categoría del repo, mezclando con indice.json."""
+    indice = load_indice()
+    # indice.json key → categoryTitle ("A. Canciones Entrada 🎉")
+    by_letter: Dict[str, dict] = {}
+    for key, info in indice.items():
+        title = info.get("categoryTitle", "")
+        m = re.match(r"\s*([A-Z](?:\+\d+)?)\.", title)
+        if m:
+            by_letter[m.group(1)] = {
+                "key": key,
+                "title": title,
+                "order": info.get("order", 999),
+            }
+    folders = []
+    for p in sorted(SONGS_DIR.iterdir()):
+        if not p.is_dir():
+            continue
+        m = re.match(r"\s*([A-Z](?:\+\d+)?)\.", p.name)
+        if not m:
+            continue
+        letter = m.group(1)
+        info = by_letter.get(letter, {})
+        folders.append({
+            "letter": letter,
+            "folder": p.name,
+            "title": info.get("title") or p.name,
+            "indice_key": info.get("key"),
+            "order": info.get("order", 999),
+        })
+    folders.sort(key=lambda x: (x["order"], x["letter"]))
+    return folders
+
+
+def list_repo_songs(category_letter: Optional[str] = None) -> List[dict]:
+    """Devuelve todas las canciones .cho del repo con metadata."""
+    out: List[dict] = []
+    for cat in list_categories():
+        if category_letter and cat["letter"] != category_letter:
+            continue
+        folder = SONGS_DIR / cat["folder"]
+        for cho in sorted(folder.glob("*.cho")):
+            try:
+                content = cho.read_text(encoding="utf-8")
+            except Exception as e:
+                content = ""
+                meta_err = str(e)
+            else:
+                meta_err = None
+            meta = parse_cho_metadata(content) if content else {}
+            out.append({
+                "path": str(cho.relative_to(REPO_DIR)),
+                "filename": cho.name,
+                "number": number_prefix(cho.name),
+                "category_letter": cat["letter"],
+                "category_folder": cat["folder"],
+                "category_title": cat["title"],
+                "title": meta.get("title", cho.stem),
+                "artist": meta.get("artist", ""),
+                "key": meta.get("key", ""),
+                "capo": meta.get("capo", 0),
+                "has_todo": meta.get("has_todo", False),
+                "error": meta_err,
+            })
+    return out
+
+
+# ─────────── Cantoral docx ─────────── #
+
+_docx_cache: Dict[str, object] = {"songs": None, "mtime": 0}
+
+
+def load_docx_songs(force: bool = False) -> List[dict]:
+    """Lee y cachea las canciones del docx. Si el archivo cambia, recarga."""
+    docx_path = d2c.find_docx()
+    mtime = docx_path.stat().st_mtime
+    if not force and _docx_cache["songs"] is not None and _docx_cache["mtime"] == mtime:
+        return _docx_cache["songs"]  # type: ignore
+    paras = d2c.load_paragraphs(docx_path)
+    raw_songs = d2c.split_into_songs(paras)
+    indexed = []
+    for i, s in enumerate(raw_songs):
+        indexed.append({
+            "id": i,
+            "title_raw": s["title_raw"],
+            "section": s["section"],
+            "section_letter": d2c.section_letter(s["section"]),
+            "_song": s,
+        })
+    _docx_cache["songs"] = indexed
+    _docx_cache["mtime"] = mtime
+    return indexed
+
+
+def docx_song_to_dict(s: dict, conv: dict, include_body: bool = False) -> dict:
+    out = {
+        "id": s["id"],
+        "title_raw": s["title_raw"],
+        "title": conv["title"],
+        "section": s["section"],
+        "section_letter": s["section_letter"],
+        "key": conv.get("key"),
+        "capo": conv.get("capo"),
+        "warnings": conv.get("warnings", []),
+        "slug": conv.get("slug"),
+    }
+    if include_body:
+        out["content"] = render_cho_with_todo(conv)
+    return out
+
+
+def render_cho_with_todo(conv: dict) -> str:
+    """Render del .cho con la línea TO DO al principio."""
+    header_lines = [TODO_COMMENT_LINE, f"{{title: {conv['title']}}}"]
+    if conv.get("key"):
+        header_lines.append(f"{{key: {conv['key']}}}")
+    if conv.get("capo"):
+        header_lines.append(f"{{capo: {conv['capo']}}}")
+    return "\n".join(header_lines) + "\n\n" + conv["body"] + "\n"
+
+
+# ─────────── Backup ─────────── #
+
+
+def backup_file(path: Path) -> Path:
+    """Copia el .cho a /songs-backup-edits/<timestamp>/<rel_path>."""
+    BACKUP_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    rel = path.relative_to(SONGS_DIR)
+    dest = BACKUP_DIR / ts / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, dest)
+    return dest
+
+
+# ─────────── API: Catálogo ─────────── #
+
+
+@app.route("/api/catalog")
+def api_catalog():
+    repo_songs = list_repo_songs()
+    docx_songs = load_docx_songs()
+
+    # Cachear conversiones (caras): solo para usar el title aquí
+    docx_convs: Dict[int, dict] = {}
+    docx_index: Dict[str, dict] = {}
+    for s in docx_songs:
+        conv = d2c.convert_song(s["_song"])
+        docx_convs[s["id"]] = conv
+        for k in title_keys(conv["title"]):
+            docx_index.setdefault(k, {
+                "id": s["id"],
+                "title": conv["title"],
+                "section_letter": s["section_letter"],
+            })
+
+    # Marcar repo_songs con si está en docx
+    matched_docx_ids: set = set()
+    for r in repo_songs:
+        match = best_match(title_keys(r["title"]), docx_index)
+        if match:
+            r["in_docx"] = True
+            r["docx_id"] = match["id"]
+            matched_docx_ids.add(match["id"])
+        else:
+            r["in_docx"] = False
+            r["docx_id"] = None
+
+    # Canciones del docx que NO están en repo
+    missing = []
+    for s in docx_songs:
+        if s["id"] in matched_docx_ids:
+            continue
+        conv = docx_convs[s["id"]]
+        missing.append({
+            "docx_id": s["id"],
+            "title": conv["title"],
+            "title_raw": s["title_raw"],
+            "section_letter": s["section_letter"],
+            "key": conv.get("key"),
+            "capo": conv.get("capo"),
+            "warnings": conv.get("warnings", []),
+        })
+
+    # Contadores
+    todo_count = sum(1 for r in repo_songs if r["has_todo"])
+
+    return jsonify({
+        "categories": list_categories(),
+        "repo_songs": repo_songs,
+        "missing_from_repo": missing,
+        "stats": {
+            "repo_total": len(repo_songs),
+            "docx_total": len(docx_songs),
+            "todo_count": todo_count,
+            "missing_from_repo": len(missing),
+            "only_in_repo": sum(1 for r in repo_songs if not r["in_docx"]),
+        },
+    })
+
+
+# ─────────── API: Canción individual ─────────── #
+
+
+@app.route("/api/song", methods=["GET"])
+def api_song_get():
+    path_str = request.args.get("path", "")
+    if not path_str:
+        abort(400, "Falta 'path'")
+    p = safe_relpath(path_str)
+    if not p.exists():
+        abort(404, "No existe")
+    content = p.read_text(encoding="utf-8")
+    meta = parse_cho_metadata(content)
+    return jsonify({
+        "path": str(p.relative_to(REPO_DIR)),
+        "filename": p.name,
+        "content": content,
+        "meta": meta,
+    })
+
+
+@app.route("/api/song", methods=["PUT"])
+def api_song_put():
+    path_str = request.args.get("path", "")
+    if not path_str:
+        abort(400, "Falta 'path'")
+    p = safe_relpath(path_str)
+    if not p.exists():
+        abort(404, "No existe")
+    body = request.get_json(silent=True) or {}
+    content = body.get("content")
+    if not isinstance(content, str):
+        abort(400, "Body debe ser {content: string}")
+    backup_file(p)
+    p.write_text(content, encoding="utf-8")
+    meta = parse_cho_metadata(content)
+    return jsonify({"ok": True, "path": str(p.relative_to(REPO_DIR)), "meta": meta})
+
+
+@app.route("/api/song", methods=["DELETE"])
+def api_song_delete():
+    path_str = request.args.get("path", "")
+    if not path_str:
+        abort(400, "Falta 'path'")
+    p = safe_relpath(path_str)
+    if not p.exists():
+        abort(404, "No existe")
+    backup_file(p)
+    p.unlink()
+    return jsonify({"ok": True})
+
+
+# ─────────── API: docx ─────────── #
+
+
+@app.route("/api/docx/list")
+def api_docx_list():
+    songs = load_docx_songs()
+    out = []
+    for s in songs:
+        conv = d2c.convert_song(s["_song"])
+        out.append(docx_song_to_dict(s, conv, include_body=False))
+    return jsonify(out)
+
+
+@app.route("/api/docx/preview")
+def api_docx_preview():
+    try:
+        i = int(request.args.get("id", "-1"))
+    except ValueError:
+        abort(400, "id inválido")
+    songs = load_docx_songs()
+    if not (0 <= i < len(songs)):
+        abort(404, "id fuera de rango")
+    s = songs[i]
+    conv = d2c.convert_song(s["_song"])
+    return jsonify(docx_song_to_dict(s, conv, include_body=True))
+
+
+@app.route("/api/docx/import", methods=["POST"])
+def api_docx_import():
+    body = request.get_json(silent=True) or {}
+    ids = body.get("ids") or []
+    if not isinstance(ids, list):
+        abort(400, "ids debe ser lista")
+    songs = load_docx_songs()
+    repo_songs = list_repo_songs()
+    repo_titles = {normalize_title_for_match(r["title"]) for r in repo_songs}
+
+    results = []
+    for i in ids:
+        try:
+            i = int(i)
+        except (TypeError, ValueError):
+            results.append({"id": i, "ok": False, "error": "id inválido"})
+            continue
+        if not (0 <= i < len(songs)):
+            results.append({"id": i, "ok": False, "error": "fuera de rango"})
+            continue
+        s = songs[i]
+        conv = d2c.convert_song(s["_song"])
+        if normalize_title_for_match(conv["title"]) in repo_titles:
+            results.append({"id": i, "ok": False, "error": "ya existe en repo"})
+            continue
+        folder = d2c.resolve_target_folder(s["section"])
+        if folder is None:
+            results.append({"id": i, "ok": False, "error": "sin carpeta destino"})
+            continue
+        num = d2c.next_song_number(folder)
+        fname = f"{num:02d}.{conv['slug']}.cho"
+        fpath = folder / fname
+        if fpath.exists():
+            results.append({"id": i, "ok": False, "error": "el archivo ya existe", "path": str(fpath.relative_to(REPO_DIR))})
+            continue
+        fpath.write_text(render_cho_with_todo(conv), encoding="utf-8")
+        repo_titles.add(normalize_title_for_match(conv["title"]))
+        results.append({
+            "id": i,
+            "ok": True,
+            "path": str(fpath.relative_to(REPO_DIR)),
+            "title": conv["title"],
+            "warnings": conv.get("warnings", []),
+        })
+    return jsonify({"results": results})
+
+
+# ─────────── API: reordenar y build-json ─────────── #
+
+
+@app.route("/api/reorder", methods=["POST"])
+def api_reorder():
+    body = request.get_json(silent=True) or {}
+    letter = body.get("category", "").upper()
+    order = body.get("order", [])
+    if not letter or not isinstance(order, list):
+        abort(400, "Falta category u order")
+    cat = next((c for c in list_categories() if c["letter"] == letter), None)
+    if not cat:
+        abort(404, "Categoría no encontrada")
+    folder = SONGS_DIR / cat["folder"]
+    current = {p.name: p for p in folder.glob("*.cho")}
+    # Validar que todos los filenames existen
+    for fn in order:
+        if fn not in current:
+            abort(400, f"Archivo no existe: {fn}")
+    # Hacer backup de la categoría completa
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_folder = BACKUP_DIR / ts / cat["folder"]
+    backup_folder.mkdir(parents=True, exist_ok=True)
+    for p in folder.glob("*.cho"):
+        shutil.copy2(p, backup_folder / p.name)
+    # Renombrar: paso intermedio con prefijo temporal para evitar colisiones
+    tmp_prefix = f".reorder-{int(time.time())}-"
+    intermediate: List[tuple[Path, str]] = []
+    for fn in order:
+        p = folder / fn
+        # Quitar prefijo numérico viejo si existe
+        base = re.sub(r"^\d+\.", "", fn)
+        intermediate.append((p, base))
+    # Renombrar a temporales
+    temp_paths: List[tuple[Path, str]] = []
+    for p, base in intermediate:
+        tp = folder / (tmp_prefix + base)
+        p.rename(tp)
+        temp_paths.append((tp, base))
+    # Renombrar a finales con números
+    final_paths = []
+    for idx, (tp, base) in enumerate(temp_paths, start=1):
+        final_name = f"{idx:02d}.{base}"
+        final = folder / final_name
+        tp.rename(final)
+        final_paths.append(final.name)
+    return jsonify({"ok": True, "category": letter, "new_order": final_paths})
+
+
+@app.route("/api/build-json", methods=["POST"])
+def api_build_json():
+    script = SCRIPTS_DIR / "crear_songs_json.py"
+    if not script.exists():
+        abort(404, "crear_songs_json.py no encontrado")
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True, text=True, cwd=str(REPO_DIR),
+    )
+    return jsonify({
+        "ok": proc.returncode == 0,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "returncode": proc.returncode,
+    })
+
+
+# ─────────── Static + fallback ─────────── #
+
+
+@app.route("/")
+def index():
+    return send_from_directory(app.static_folder, "index.html")
+
+
+@app.route("/api/health")
+def api_health():
+    try:
+        docx = d2c.find_docx()
+        docx_ok = docx.exists()
+    except SystemExit:
+        docx_ok = False
+    return jsonify({
+        "ok": True,
+        "songs_dir": str(SONGS_DIR),
+        "docx_ok": docx_ok,
+        "endpoints": [
+            "GET  /api/catalog",
+            "GET  /api/song?path=...",
+            "PUT  /api/song?path=...",
+            "DELETE /api/song?path=...",
+            "GET  /api/docx/list",
+            "GET  /api/docx/preview?id=N",
+            "POST /api/docx/import",
+            "POST /api/reorder",
+            "POST /api/build-json",
+        ],
+    })
+
+
+def main():
+    port = int(os.environ.get("CANTORAL_ADMIN_PORT", "8765"))
+    host = os.environ.get("CANTORAL_ADMIN_HOST", "127.0.0.1")
+    print(f"\n🎵  Cantoral Admin\n   Abre  http://{host}:{port}/\n   Ctrl+C para parar\n")
+    app.run(host=host, port=port, debug=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -366,6 +366,56 @@ def api_song_put():
     return jsonify({"ok": True, "path": str(p.relative_to(REPO_DIR)), "meta": meta})
 
 
+@app.route("/api/song/new", methods=["POST"])
+def api_song_new():
+    body = request.get_json(silent=True) or {}
+    cat_letter = (body.get("category") or "").upper()
+    title = (body.get("title") or "").strip()
+    artist = (body.get("artist") or "").strip()
+    key = (body.get("key") or "").strip()
+    capo = body.get("capo") or 0
+    mode = body.get("mode") or "blank"
+    user_content = body.get("content") or ""
+    if not cat_letter or not title:
+        abort(400, "Falta category o title")
+    cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
+    if not cat:
+        abort(404, "Categoría no encontrada")
+    folder = SONGS_DIR / cat["folder"]
+    folder.mkdir(exist_ok=True)
+    num = d2c.next_song_number(folder)
+    slug = d2c.slugify(d2c.pretty_title_case(title))
+    fname = f"{num:02d}.{slug}.cho"
+    fpath = folder / fname
+    if fpath.exists():
+        abort(409, "Ya existe un archivo con ese nombre")
+
+    if mode == "chordpro" and user_content.strip():
+        # Limpieza mínima: asegurar que tiene la línea TO DO al principio
+        content = user_content
+        if not TODO_REGEX.search(content):
+            content = TODO_COMMENT_LINE + "\n" + content
+        # Asegurar el title si no está
+        if not re.search(r"\{\s*title", content, re.IGNORECASE):
+            content = content.rstrip() + "\n"
+            content = TODO_COMMENT_LINE + "\n" + f"{{title: {title}}}\n" + content.lstrip(TODO_COMMENT_LINE).lstrip("\n")
+    else:
+        # Modo blank
+        header = [TODO_COMMENT_LINE, f"{{title: {title}}}"]
+        if artist: header.append(f"{{artist: {artist}}}")
+        if key: header.append(f"{{key: {key}}}")
+        if capo: header.append(f"{{capo: {capo}}}")
+        body_text = "" if mode == "blank" else user_content
+        content = "\n".join(header) + "\n\n" + body_text
+
+    fpath.write_text(content, encoding="utf-8")
+    return jsonify({
+        "ok": True,
+        "path": str(fpath.relative_to(REPO_DIR)),
+        "filename": fname,
+    })
+
+
 @app.route("/api/song", methods=["DELETE"])
 def api_song_delete():
     path_str = request.args.get("path", "")

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -231,6 +231,7 @@ function app() {
         this.setSaveIndicator('saved', '✓ Cargada');
         // Pre-parsear porque visual es el tab por defecto
         this.editor.parsed = parseCho(this.editor.content);
+        this.markChorusFlags();
         this.$nextTick(() => this.layoutChords());
       } catch (e) {
         alert('Error abriendo: ' + e.message);
@@ -249,16 +250,14 @@ function app() {
       this.setSaveIndicator('saved', 'Sin cambios');
     },
     setEditorTab(t) {
-      // Sincronizar entre tabs según la dirección
       if (this.editor.tab === 'visual' && t !== 'visual') {
-        // visual → otro: serializar parsed → content
         this.editor.content = serializeCho(this.editor.parsed);
         this.refreshMetaFromRaw();
       }
       this.editor.tab = t;
       if (t === 'visual') {
-        // raw → visual: parsear content
         this.editor.parsed = parseCho(this.editor.content);
+        this.markChorusFlags();
         this.$nextTick(() => this.layoutChords());
       }
     },
@@ -350,16 +349,20 @@ function app() {
             const d = Math.abs(cx - dropX);
             if (d < bestDist) { bestDist = d; bestIdx = i; }
           });
-          // Word-start snap unless Shift held
-          if (!e.shiftKey) {
-            const ln = self.editor.parsed[dragState.lineIdx];
+          // Snap mode según modificadores:
+          //   sin modif. → snap a inicio de palabra
+          //   Shift     → snap a inicio de sílaba (más fino)
+          //   Alt       → sin snap (pixel-perfect carácter a carácter)
+          const ln = self.editor.parsed[dragState.lineIdx];
+          if (e.altKey) {
+            // no snap
+          } else if (e.shiftKey) {
+            bestIdx = snapToSyllable(bestIdx, ln.lyric);
+          } else {
             bestIdx = snapToWordStart(bestIdx, ln.lyric);
           }
-          const ln = self.editor.parsed[dragState.lineIdx];
           ln.chords[dragState.chordIdx].pos = bestIdx;
-          self.editor.dirty = true;
-          self.editor.content = serializeCho(self.editor.parsed);
-          self.refreshMetaFromRaw();
+          self.commitParsed();
           self.layoutChords();
           dragState = null;
         }
@@ -377,14 +380,11 @@ function app() {
         if (next != null) {
           const v = next.trim();
           if (v === '') {
-            // delete
             self.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
           } else {
             self.editor.parsed[lineIdx].chords[chordIdx].text = v;
           }
-          self.editor.dirty = true;
-          self.editor.content = serializeCho(self.editor.parsed);
-          self.refreshMetaFromRaw();
+          self.commitParsed();
           self.layoutChords();
         }
       });
@@ -395,9 +395,7 @@ function app() {
         const chordIdx = parseInt(el.dataset.chordIdx, 10);
         if (confirm('¿Borrar este acorde?')) {
           self.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
-          self.editor.dirty = true;
-          self.editor.content = serializeCho(self.editor.parsed);
-          self.refreshMetaFromRaw();
+          self.commitParsed();
           self.layoutChords();
         }
       });
@@ -422,9 +420,7 @@ function app() {
       if (!text || !text.trim()) return;
       this.editor.parsed[lineIdx].chords.push({ text: text.trim(), pos: charIdx });
       this.editor.parsed[lineIdx].chords.sort((a, b) => a.pos - b.pos);
-      this.editor.dirty = true;
-      this.editor.content = serializeCho(this.editor.parsed);
-      this.refreshMetaFromRaw();
+      this.commitParsed();
       this.visualAddMode = false;
       this.$nextTick(() => this.layoutChords());
     },
@@ -433,11 +429,217 @@ function app() {
       if (!this.visualSelectedChord) return;
       const { lineIdx, chordIdx } = this.visualSelectedChord;
       this.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
+      this.commitParsed();
+      this.visualSelectedChord = null;
+      this.layoutChords();
+    },
+
+    // ─────────── Helpers de actualización ───────────
+    commitParsed() {
       this.editor.dirty = true;
       this.editor.content = serializeCho(this.editor.parsed);
       this.refreshMetaFromRaw();
-      this.visualSelectedChord = null;
-      this.layoutChords();
+    },
+
+    lineCssClass(ln, idx) {
+      const cls = ['ed-line', 'ed-' + ln.type];
+      if (this.visualSelectedLines.has(idx)) cls.push('selected');
+      if (ln._inChorus) cls.push('in-chorus');
+      return cls.join(' ');
+    },
+
+    // ─────────── Selección de líneas (gutter) ───────────
+    toggleLineSelection(idx, ev) {
+      if (ev && ev.shiftKey && this.visualLastClickedLine != null) {
+        const lo = Math.min(this.visualLastClickedLine, idx);
+        const hi = Math.max(this.visualLastClickedLine, idx);
+        for (let i = lo; i <= hi; i++) this.visualSelectedLines.add(i);
+      } else {
+        if (this.visualSelectedLines.has(idx)) this.visualSelectedLines.delete(idx);
+        else this.visualSelectedLines.add(idx);
+        this.visualLastClickedLine = idx;
+      }
+      this.visualSelectedLines = new Set(this.visualSelectedLines);  // trigger Alpine
+    },
+    clearLineSelection() {
+      this.visualSelectedLines = new Set();
+      this.visualLastClickedLine = null;
+    },
+    selectedLineRange() {
+      const arr = [...this.visualSelectedLines].sort((a, b) => a - b);
+      if (arr.length === 0) return null;
+      // Tomamos el rango entre min y max (contiguo)
+      return { start: arr[0], end: arr[arr.length - 1] };
+    },
+
+    // ─────────── Estribillo: marcar / desmarcar / insertar ───────────
+    markSelectionAsChorus() {
+      const r = this.selectedLineRange();
+      if (!r) return;
+      // Insertar {eoc} después de r.end y {soc} antes de r.start
+      // Pero antes: eliminar cualquier {soc}/{eoc} dentro del rango
+      const newParsed = [...this.editor.parsed];
+      // Filtramos dentro: marcar los soc/eoc dentro del rango para borrar luego
+      const toRemove = new Set();
+      for (let i = r.start; i <= r.end; i++) {
+        if (newParsed[i] && (newParsed[i].type === 'soc' || newParsed[i].type === 'eoc')) {
+          toRemove.add(i);
+        }
+      }
+      const filtered = newParsed.filter((_, i) => !toRemove.has(i));
+      // Recalcular el rango (los índices después de quitar pueden haber cambiado)
+      // Simplificación: contamos cuántos toRemove están antes de r.start / r.end
+      const removedBeforeStart = [...toRemove].filter(i => i < r.start).length;
+      const removedInRange = toRemove.size - removedBeforeStart;
+      const newStart = r.start - removedBeforeStart;
+      const newEnd = r.end - removedBeforeStart - removedInRange;
+      // Insertar {eoc} después de newEnd, luego {soc} antes de newStart
+      filtered.splice(newEnd + 1, 0, { type: 'eoc', raw: '{eoc}' });
+      filtered.splice(newStart, 0, { type: 'soc', raw: '{soc}' });
+      this.editor.parsed = filtered;
+      this.clearLineSelection();
+      this.commitParsed();
+      this.markChorusFlags();
+      this.$nextTick(() => this.layoutChords());
+    },
+    unmarkSelectionChorus() {
+      const r = this.selectedLineRange();
+      if (!r) return;
+      // Quitar todos los {soc}/{eoc} dentro del rango y los inmediatamente antes/después
+      const toRemove = new Set();
+      for (let i = Math.max(0, r.start - 2); i <= Math.min(this.editor.parsed.length - 1, r.end + 2); i++) {
+        const ln = this.editor.parsed[i];
+        if (ln && (ln.type === 'soc' || ln.type === 'eoc')) toRemove.add(i);
+      }
+      this.editor.parsed = this.editor.parsed.filter((_, i) => !toRemove.has(i));
+      this.clearLineSelection();
+      this.commitParsed();
+      this.markChorusFlags();
+      this.$nextTick(() => this.layoutChords());
+    },
+    removeChorusMarkerAt(idx) {
+      this.editor.parsed.splice(idx, 1);
+      this.commitParsed();
+      this.markChorusFlags();
+      this.$nextTick(() => this.layoutChords());
+    },
+    markChorusFlags() {
+      // Anota _inChorus en líneas que estén entre {soc}/{eoc}
+      let inside = false;
+      for (const ln of this.editor.parsed) {
+        if (ln.type === 'soc') { inside = true; ln._inChorus = false; continue; }
+        if (ln.type === 'eoc') { inside = false; ln._inChorus = false; continue; }
+        ln._inChorus = inside;
+      }
+    },
+
+    // Devuelve [{startIdx, endIdx, lines}] de cada bloque de estribillo (entre soc/eoc).
+    getChorusBlocks() {
+      const blocks = [];
+      let curStart = -1;
+      this.editor.parsed.forEach((ln, i) => {
+        if (ln.type === 'soc') { curStart = i; }
+        else if (ln.type === 'eoc' && curStart >= 0) {
+          const inner = this.editor.parsed.slice(curStart + 1, i);
+          blocks.push({ startIdx: curStart, endIdx: i, lines: inner });
+          curStart = -1;
+        }
+      });
+      return blocks;
+    },
+    insertChorusHere() {
+      const blocks = this.getChorusBlocks();
+      if (blocks.length === 0) return;
+      let chosen = 0;
+      if (blocks.length > 1) {
+        const opts = blocks.map((b, i) => {
+          const preview = b.lines
+            .filter(l => l.type === 'lyric')
+            .map(l => l.lyric)
+            .join(' / ')
+            .slice(0, 60);
+          return `${i + 1}. ${preview}`;
+        }).join('\n');
+        const r = prompt(`Hay ${blocks.length} estribillos. ¿Cuál insertar? (1-${blocks.length})\n\n${opts}`, '1');
+        if (!r) return;
+        const n = parseInt(r, 10);
+        if (isNaN(n) || n < 1 || n > blocks.length) return;
+        chosen = n - 1;
+      }
+      const block = blocks[chosen];
+      // Clonar las líneas (deep clone para no afectar al original)
+      const clone = JSON.parse(JSON.stringify(this.editor.parsed.slice(block.startIdx, block.endIdx + 1)));
+      // Insertar después de la última línea seleccionada (o al final del doc si no hay)
+      const r = this.selectedLineRange();
+      let insertAt = r ? r.end + 1 : this.editor.parsed.length;
+      // Añadir línea blanca de separación antes y después
+      const toInsert = [{ type: 'blank', raw: '' }, ...clone, { type: 'blank', raw: '' }];
+      this.editor.parsed.splice(insertAt, 0, ...toInsert);
+      this.commitParsed();
+      this.markChorusFlags();
+      this.$nextTick(() => this.layoutChords());
+    },
+
+    // ─────────── Copiar / pegar patrón de acordes ───────────
+    copyChordPattern() {
+      const r = this.selectedLineRange();
+      if (!r) return;
+      const pattern = [];
+      for (let i = r.start; i <= r.end; i++) {
+        const ln = this.editor.parsed[i];
+        if (ln && ln.type === 'lyric') {
+          pattern.push({
+            lyric: ln.lyric,
+            chords: JSON.parse(JSON.stringify(ln.chords)),
+          });
+        }
+      }
+      if (pattern.length === 0) { alert('No hay líneas de letra en la selección.'); return; }
+      this.visualChordClipboard = pattern;
+      const total = pattern.reduce((acc, p) => acc + p.chords.length, 0);
+      this.setSaveIndicator('saved', `📋 ${total} acordes copiados de ${pattern.length} línea(s)`);
+      setTimeout(() => { if (this.editor.dirty) this.setSaveIndicator('dirty', '● Sin guardar'); }, 2500);
+    },
+    pasteChordPattern() {
+      const r = this.selectedLineRange();
+      if (!r || !this.visualChordClipboard) return;
+      // Recoger las líneas de letra de la selección
+      const targets = [];
+      for (let i = r.start; i <= r.end; i++) {
+        const ln = this.editor.parsed[i];
+        if (ln && ln.type === 'lyric') targets.push(ln);
+      }
+      if (targets.length === 0) { alert('No hay líneas de letra en la selección.'); return; }
+      // Mapear: línea N del clipboard → línea N del target (si existe)
+      for (let n = 0; n < targets.length; n++) {
+        const src = this.visualChordClipboard[Math.min(n, this.visualChordClipboard.length - 1)];
+        targets[n].chords = mapChordsByWord(src, targets[n].lyric);
+      }
+      this.commitParsed();
+      this.$nextTick(() => this.layoutChords());
+    },
+
+    // ─────────── Editar texto de la letra ───────────
+    editLyricLine(idx) {
+      const ln = this.editor.parsed[idx];
+      if (!ln || ln.type !== 'lyric') return;
+      const next = prompt('Edita el texto de esta línea (los acordes intentan mantenerse pegados a su palabra):', ln.lyric);
+      if (next == null || next === ln.lyric) return;
+      // Mapear posiciones de acordes al nuevo texto por word-index
+      const oldStarts = wordStarts(ln.lyric);
+      const newStarts = wordStarts(next);
+      ln.chords = ln.chords.map(ch => {
+        // Encontrar a qué palabra pertenecía
+        let wordIdx = 0;
+        for (let k = 0; k < oldStarts.length; k++) {
+          if (oldStarts[k] <= ch.pos) wordIdx = k; else break;
+        }
+        const newPos = newStarts[Math.min(wordIdx, newStarts.length - 1)] || Math.min(ch.pos, next.length);
+        return { text: ch.text, pos: newPos };
+      });
+      ln.lyric = next;
+      this.commitParsed();
+      this.$nextTick(() => this.layoutChords());
     },
 
     refreshMetaFromRaw() {
@@ -672,6 +874,120 @@ function snapToWordStart(idx, lyric) {
   return best;
 }
 function isSpace(ch) { return ch === ' ' || ch === '\t'; }
+
+function wordStarts(lyric) {
+  if (!lyric) return [0];
+  const starts = [];
+  if (!isSpace(lyric[0] || ' ')) starts.push(0);
+  for (let i = 1; i < lyric.length; i++) {
+    if (!isSpace(lyric[i]) && isSpace(lyric[i - 1])) starts.push(i);
+  }
+  if (starts.length === 0) starts.push(0);
+  return starts;
+}
+
+// Mapea acordes desde {lyric: src, chords: [...]} a un newLyric, alineando por índice de palabra.
+function mapChordsByWord(srcLine, newLyric) {
+  const srcStarts = wordStarts(srcLine.lyric);
+  const newStarts = wordStarts(newLyric);
+  // Para cada acorde, encontrar a qué palabra pertenecía (la última cuyo start <= pos)
+  const out = [];
+  for (const ch of srcLine.chords) {
+    let wordIdx = 0;
+    for (let i = 0; i < srcStarts.length; i++) {
+      if (srcStarts[i] <= ch.pos) wordIdx = i;
+      else break;
+    }
+    let newPos;
+    if (wordIdx < newStarts.length) {
+      newPos = newStarts[wordIdx];
+      // Si el acorde estaba más a la derecha que el inicio de palabra (caso raro), lo respetamos proporcionalmente
+      const srcWordStart = srcStarts[wordIdx];
+      const srcWordEnd = (srcStarts[wordIdx + 1] != null) ? srcStarts[wordIdx + 1] : srcLine.lyric.length;
+      const newWordEnd = (newStarts[wordIdx + 1] != null) ? newStarts[wordIdx + 1] : newLyric.length;
+      const srcWordLen = Math.max(1, srcWordEnd - srcWordStart);
+      const newWordLen = Math.max(1, newWordEnd - newPos);
+      const offsetInWord = ch.pos - srcWordStart;
+      const ratio = offsetInWord / srcWordLen;
+      newPos = newPos + Math.round(ratio * newWordLen);
+      newPos = Math.min(newPos, newLyric.length);
+    } else {
+      newPos = newLyric.length;
+    }
+    out.push({ text: ch.text, pos: newPos });
+  }
+  return out;
+}
+
+// ─────────── Silabeado español sencillo ───────────
+const SP_STRONG = new Set(['a','e','o','á','é','ó']);
+const SP_WEAK_UNACC = new Set(['i','u','ü']);
+const SP_WEAK_ACC = new Set(['í','ú']);
+const SP_VOW = new Set([...SP_STRONG, ...SP_WEAK_UNACC, ...SP_WEAK_ACC]);
+const SP_INSEP = new Set(['pr','br','tr','dr','cr','gr','fr','pl','bl','cl','gl','fl','ch','ll','rr']);
+
+function isVow(c) { return SP_VOW.has((c || '').toLowerCase()); }
+
+function syllableStartsInWord(word) {
+  // Devuelve los índices (relativos al inicio de la palabra) donde empieza cada sílaba.
+  if (!word) return [0];
+  const w = word.toLowerCase();
+  const starts = [0];
+  let i = 0;
+  while (i < w.length) {
+    // saltar consonantes iniciales (ya están en la sílaba actual)
+    while (i < w.length && !isVow(w[i])) i++;
+    // saltar el núcleo vocálico (diptongo si corresponde — simplificado)
+    while (i < w.length && isVow(w[i])) i++;
+    // cluster consonántico hasta la siguiente vocal
+    const cStart = i;
+    while (i < w.length && !isVow(w[i])) i++;
+    if (i >= w.length) break;  // fin de palabra
+    const cluster = w.slice(cStart, i);
+    let nextSyl;
+    if (cluster.length === 0) nextSyl = i;
+    else if (cluster.length === 1) nextSyl = cStart;  // V-CV
+    else if (cluster.length === 2) {
+      nextSyl = SP_INSEP.has(cluster) ? cStart : cStart + 1;
+    } else {
+      const last2 = cluster.slice(-2);
+      nextSyl = SP_INSEP.has(last2) ? i - 2 : i - 1;
+    }
+    if (nextSyl > starts[starts.length - 1]) starts.push(nextSyl);
+  }
+  return starts;
+}
+
+function syllableStartsInLine(lyric) {
+  if (!lyric) return [0];
+  const starts = [];
+  let wstart = -1;
+  for (let i = 0; i <= lyric.length; i++) {
+    const ch = lyric[i];
+    if (i === lyric.length || isSpace(ch)) {
+      if (wstart >= 0) {
+        const word = lyric.slice(wstart, i);
+        for (const s of syllableStartsInWord(word)) starts.push(wstart + s);
+        wstart = -1;
+      }
+    } else if (wstart === -1) {
+      wstart = i;
+    }
+  }
+  starts.push(lyric.length);
+  return starts;
+}
+
+function snapToSyllable(idx, lyric) {
+  const starts = syllableStartsInLine(lyric);
+  if (starts.length === 0) return idx;
+  let best = starts[0], bestDist = Infinity;
+  for (const s of starts) {
+    const d = Math.abs(s - idx);
+    if (d < bestDist) { bestDist = d; best = s; }
+  }
+  return best;
+}
 
 // Render a ChordPro line: produces stacked chord/lyric HTML.
 function renderChordLine(line) {

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -44,10 +44,28 @@ function app() {
       parsed: [],
     },
     visualAddMode: false,
-    visualSelectedChord: null,  // {lineIdx, chordIdx}
+    visualSelectedChord: null,
+    visualSelectedLines: new Set(),
+    visualLastClickedLine: null,
+    visualChordClipboard: null,   // [{lyric, chords}]  patrón copiado
+    showHelp: false,
+    newSong: { open: false, category: '', title: '', artist: '', key: '', capo: 0,
+               mode: 'blank', content: '', creating: false },
+    saveIndicator: { text: 'Sin cambios', cls: 'saved' },
+    lastSaveAt: null,
 
     // ─────────── Lifecycle ───────────
     async boot() {
+      this.$watch('editor.dirty', (v) => {
+        if (v) this.setSaveIndicator('dirty', '● Sin guardar — pulsa 💾');
+      });
+      // Atajo global: Ctrl/Cmd+S
+      window.addEventListener('keydown', (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 's' && this.editor.path) {
+          e.preventDefault();
+          this.saveSong();
+        }
+      });
       await this.loadCatalog();
     },
 
@@ -204,9 +222,16 @@ function app() {
           content: json.content,
           originalContent: json.content,
           dirty: false,
-          tab: 'raw',
+          tab: 'visual',  // por defecto abrimos en visual
           meta: { ...json.meta },
+          parsed: [],
         };
+        this.visualSelectedLines = new Set();
+        this.visualSelectedChord = null;
+        this.setSaveIndicator('saved', '✓ Cargada');
+        // Pre-parsear porque visual es el tab por defecto
+        this.editor.parsed = parseCho(this.editor.content);
+        this.$nextTick(() => this.layoutChords());
       } catch (e) {
         alert('Error abriendo: ' + e.message);
       }
@@ -215,9 +240,13 @@ function app() {
       if (this.editor.dirty && !confirm('Hay cambios sin guardar. ¿Descartar?')) return;
       this.editor = {
         path: null, filename: null, content: '', originalContent: '',
-        dirty: false, tab: 'raw',
+        dirty: false, tab: 'visual',
         meta: { title: '', artist: '', key: '', capo: 0, has_todo: false },
+        parsed: [],
       };
+      this.visualSelectedLines = new Set();
+      this.visualSelectedChord = null;
+      this.setSaveIndicator('saved', 'Sin cambios');
     },
     setEditorTab(t) {
       // Sincronizar entre tabs según la dirección
@@ -450,6 +479,7 @@ function app() {
     },
     async saveSong() {
       if (!this.editor.dirty) return;
+      this.setSaveIndicator('saving', 'Guardando…');
       try {
         const r = await fetch('/api/song?path=' + encodeURIComponent(this.editor.path), {
           method: 'PUT',
@@ -459,11 +489,15 @@ function app() {
         if (!r.ok) throw new Error('HTTP ' + r.status);
         this.editor.originalContent = this.editor.content;
         this.editor.dirty = false;
+        this.lastSaveAt = new Date();
+        this.setSaveIndicator('saved', '✓ Guardado · haz commit cuando termines');
         await this.loadCatalog();
       } catch (e) {
+        this.setSaveIndicator('error', '✗ Error guardando');
         alert('Error guardando: ' + e.message);
       }
     },
+    setSaveIndicator(cls, text) { this.saveIndicator = { cls, text }; },
     async deleteSong(r) {
       if (!confirm(`¿Borrar "${r.title}" (${r.filename})? Se hace backup en songs-backup-edits.`)) return;
       try {
@@ -485,19 +519,40 @@ function app() {
       }
     },
 
-    // ─────────── Build JSON ───────────
-    async buildJson() {
-      this.building = true;
-      this.buildResult = '';
+    // ─────────── Nueva canción ───────────
+    openNewSongModal() {
+      this.newSong = { open: true, category: '', title: '', artist: '', key: '', capo: 0,
+                       mode: 'blank', content: '', creating: false };
+    },
+    async createNewSong() {
+      if (!this.newSong.category || !this.newSong.title) return;
+      this.newSong.creating = true;
       try {
-        const r = await fetch('/api/build-json', { method: 'POST' });
-        const json = await r.json();
-        this.buildResult = (json.ok ? '✓ OK\n\n' : '✗ Error (rc=' + json.returncode + ')\n\n') +
-          (json.stdout || '') + (json.stderr ? '\nSTDERR:\n' + json.stderr : '');
+        const r = await fetch('/api/song/new', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            category: this.newSong.category,
+            title: this.newSong.title,
+            artist: this.newSong.artist,
+            key: this.newSong.key,
+            capo: parseInt(this.newSong.capo) || 0,
+            mode: this.newSong.mode,
+            content: this.newSong.content,
+          }),
+        });
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({}));
+          throw new Error(err.error || ('HTTP ' + r.status));
+        }
+        const { path } = await r.json();
+        this.newSong.open = false;
+        await this.loadCatalog();
+        await this.openEditor(path);
       } catch (e) {
-        this.buildResult = 'Error: ' + e.message;
+        alert('Error creando: ' + e.message);
       } finally {
-        this.building = false;
+        this.newSong.creating = false;
       }
     },
 
@@ -644,13 +699,12 @@ function renderChordLine(line) {
   let textBuf = '';
   for (const t of tokens) {
     if (t.chord != null) {
-      // flush previous segment first
       if (textBuf || pendingChords.length) {
         html.push(`<span class="pv-seg"><span class="pv-chords">${pendingChords.map(esc).join(' ')}</span><span class="pv-lyr">${esc(textBuf) || '&nbsp;'}</span></span>`);
         pendingChords = [];
         textBuf = '';
       }
-      pendingChords.push('[' + t.chord + ']');
+      pendingChords.push(t.chord);  // sin corchetes en el preview
     } else {
       textBuf += t.char;
     }

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -1,0 +1,383 @@
+// Cantoral Admin - Alpine.js single-page app
+// Phase 3a/3b: catalog + raw editor + import. Visual drag&drop comes in 3c.
+
+function app() {
+  return {
+    // ─────────── State ───────────
+    view: 'dashboard',
+    theme: localStorage.theme || 'light',
+    loading: false,
+    error: null,
+    data: null,
+    building: false,
+    buildResult: '',
+
+    // Catalog filters
+    categoryFilter: '',
+    search: '',
+    todoFilter: false,
+    onlyInRepoFilter: false,
+
+    // Import view
+    importSearch: '',
+    importSectionFilter: '',
+    selectedImports: new Set(),
+    importing: false,
+    importResults: [],
+    docxPreview: null,
+
+    // Reorder
+    reorderCategory: '',
+    reorderSongs: [],
+    reorderModified: false,
+    reorderDragIdx: null,
+
+    // Editor
+    editor: {
+      path: null,
+      filename: null,
+      content: '',
+      originalContent: '',
+      dirty: false,
+      tab: 'raw',
+      meta: { title: '', artist: '', key: '', capo: 0, has_todo: false },
+    },
+
+    // ─────────── Lifecycle ───────────
+    async boot() {
+      await this.loadCatalog();
+    },
+
+    async loadCatalog() {
+      this.loading = true;
+      this.error = null;
+      try {
+        const r = await fetch('/api/catalog');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        this.data = await r.json();
+      } catch (e) {
+        this.error = 'No pude cargar el catálogo: ' + e.message;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    // ─────────── Helpers ───────────
+    countByCat(letter) {
+      if (!this.data) return 0;
+      return this.data.repo_songs.filter(r => r.category_letter === letter).length;
+    },
+    categoryName(letter) {
+      const c = this.data && this.data.categories.find(c => c.letter === letter);
+      return c ? c.title : letter;
+    },
+    normalizeSearch(s) {
+      return (s || '').toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    },
+
+    // ─────────── Catalog filtering ───────────
+    filteredRepoSongs() {
+      if (!this.data) return [];
+      let list = this.data.repo_songs;
+      if (this.categoryFilter) list = list.filter(r => r.category_letter === this.categoryFilter);
+      if (this.todoFilter) list = list.filter(r => r.has_todo);
+      if (this.onlyInRepoFilter) list = list.filter(r => !r.in_docx);
+      if (this.search) {
+        const q = this.normalizeSearch(this.search);
+        list = list.filter(r =>
+          this.normalizeSearch(r.title).includes(q) ||
+          this.normalizeSearch(r.artist).includes(q)
+        );
+      }
+      return list;
+    },
+
+    // ─────────── Import view ───────────
+    filteredMissing() {
+      if (!this.data) return [];
+      let list = this.data.missing_from_repo;
+      if (this.importSectionFilter) list = list.filter(m => m.section_letter === this.importSectionFilter);
+      if (this.importSearch) {
+        const q = this.normalizeSearch(this.importSearch);
+        list = list.filter(m => this.normalizeSearch(m.title).includes(q));
+      }
+      return list;
+    },
+    toggleImport(id) {
+      if (this.selectedImports.has(id)) this.selectedImports.delete(id);
+      else this.selectedImports.add(id);
+      // Force Alpine refresh
+      this.selectedImports = new Set(this.selectedImports);
+    },
+    selectAllImport() {
+      const ids = this.filteredMissing().map(m => m.docx_id);
+      this.selectedImports = new Set([...this.selectedImports, ...ids]);
+    },
+    async doImport() {
+      if (this.selectedImports.size === 0) return;
+      this.importing = true;
+      this.importResults = [];
+      try {
+        const r = await fetch('/api/docx/import', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: [...this.selectedImports] }),
+        });
+        const json = await r.json();
+        this.importResults = json.results || [];
+        this.selectedImports = new Set();
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error importando: ' + e.message);
+      } finally {
+        this.importing = false;
+      }
+    },
+    async importOne(id) {
+      this.selectedImports = new Set([id]);
+      await this.doImport();
+      this.docxPreview = null;
+    },
+    async previewDocx(id) {
+      try {
+        const r = await fetch('/api/docx/preview?id=' + id);
+        this.docxPreview = await r.json();
+        this.docxPreview.id = id;
+      } catch (e) {
+        alert('No pude generar el preview: ' + e.message);
+      }
+    },
+
+    // ─────────── Reorder ───────────
+    async loadReorder() {
+      if (!this.reorderCategory) {
+        this.reorderSongs = [];
+        this.reorderModified = false;
+        return;
+      }
+      this.reorderSongs = this.data.repo_songs
+        .filter(r => r.category_letter === this.reorderCategory)
+        .sort((a, b) => (a.number || 999) - (b.number || 999));
+      this.reorderModified = false;
+    },
+    onReorderDrop(targetIdx) {
+      if (this.reorderDragIdx == null || this.reorderDragIdx === targetIdx) return;
+      const arr = this.reorderSongs;
+      const [moved] = arr.splice(this.reorderDragIdx, 1);
+      arr.splice(targetIdx, 0, moved);
+      this.reorderSongs = [...arr];
+      this.reorderModified = true;
+      this.reorderDragIdx = null;
+    },
+    async applyReorder() {
+      if (!this.reorderCategory || !this.reorderModified) return;
+      try {
+        const r = await fetch('/api/reorder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            category: this.reorderCategory,
+            order: this.reorderSongs.map(s => s.filename),
+          }),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        await this.loadCatalog();
+        await this.loadReorder();
+        alert('Orden aplicado.');
+      } catch (e) {
+        alert('Error reordenando: ' + e.message);
+      }
+    },
+
+    // ─────────── Editor ───────────
+    async openEditor(path) {
+      try {
+        const r = await fetch('/api/song?path=' + encodeURIComponent(path));
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const json = await r.json();
+        this.editor = {
+          path: json.path,
+          filename: json.filename,
+          content: json.content,
+          originalContent: json.content,
+          dirty: false,
+          tab: 'raw',
+          meta: { ...json.meta },
+        };
+      } catch (e) {
+        alert('Error abriendo: ' + e.message);
+      }
+    },
+    closeEditor() {
+      if (this.editor.dirty && !confirm('Hay cambios sin guardar. ¿Descartar?')) return;
+      this.editor = {
+        path: null, filename: null, content: '', originalContent: '',
+        dirty: false, tab: 'raw',
+        meta: { title: '', artist: '', key: '', capo: 0, has_todo: false },
+      };
+    },
+    setEditorTab(t) { this.editor.tab = t; },
+    refreshMetaFromRaw() {
+      const c = this.editor.content;
+      const get = (k) => {
+        const m = c.match(new RegExp('\\{\\s*' + k + '\\s*:\\s*(.*?)\\s*\\}', 'i'));
+        return m ? m[1] : '';
+      };
+      this.editor.meta.title = get('title');
+      this.editor.meta.artist = get('artist') || get('author');
+      this.editor.meta.key = get('key');
+      const capoStr = get('capo');
+      this.editor.meta.capo = /^\d+$/.test(capoStr) ? parseInt(capoStr, 10) : 0;
+      this.editor.meta.has_todo = /\bTO\s+DO\b/i.test(c);
+    },
+    updateMetaInRaw(key, value) {
+      // Updates the {key: value} line in the raw content. If absent, inserts after title.
+      const c = this.editor.content;
+      const re = new RegExp('\\{\\s*' + key + '\\s*:\\s*[^}]*\\}', 'i');
+      const replacement = `{${key}: ${value}}`;
+      let next;
+      if (re.test(c)) {
+        next = c.replace(re, replacement);
+      } else {
+        // insert after first non-comment header line, or at top
+        const lines = c.split('\n');
+        let insertAt = 0;
+        for (let i = 0; i < lines.length; i++) {
+          if (/^\{(title|comment|artist|author|key|capo)/i.test(lines[i])) insertAt = i + 1;
+          else if (lines[i].trim() === '' && insertAt > 0) break;
+        }
+        lines.splice(insertAt, 0, replacement);
+        next = lines.join('\n');
+      }
+      if (next !== c) {
+        this.editor.content = next;
+        this.editor.dirty = true;
+      }
+    },
+    async saveSong() {
+      if (!this.editor.dirty) return;
+      try {
+        const r = await fetch('/api/song?path=' + encodeURIComponent(this.editor.path), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: this.editor.content }),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        this.editor.originalContent = this.editor.content;
+        this.editor.dirty = false;
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error guardando: ' + e.message);
+      }
+    },
+    async deleteSong(r) {
+      if (!confirm(`¿Borrar "${r.title}" (${r.filename})? Se hace backup en songs-backup-edits.`)) return;
+      try {
+        const res = await fetch('/api/song?path=' + encodeURIComponent(r.path), { method: 'DELETE' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error: ' + e.message);
+      }
+    },
+    markReviewed() {
+      // Remove the TO DO comment line
+      const lines = this.editor.content.split('\n');
+      const filtered = lines.filter(ln => !/\{\s*comment\s*:[^}]*\bTO\s+DO\b[^}]*\}/i.test(ln));
+      if (filtered.length !== lines.length) {
+        this.editor.content = filtered.join('\n');
+        this.editor.dirty = true;
+        this.editor.meta.has_todo = false;
+      }
+    },
+
+    // ─────────── Build JSON ───────────
+    async buildJson() {
+      this.building = true;
+      this.buildResult = '';
+      try {
+        const r = await fetch('/api/build-json', { method: 'POST' });
+        const json = await r.json();
+        this.buildResult = (json.ok ? '✓ OK\n\n' : '✗ Error (rc=' + json.returncode + ')\n\n') +
+          (json.stdout || '') + (json.stderr ? '\nSTDERR:\n' + json.stderr : '');
+      } catch (e) {
+        this.buildResult = 'Error: ' + e.message;
+      } finally {
+        this.building = false;
+      }
+    },
+
+    // ─────────── Preview HTML render ───────────
+    renderPreviewHtml(cho) {
+      if (!cho) return '';
+      const esc = (s) => String(s).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+      }[c]));
+      const lines = cho.split('\n');
+      const out = [];
+      let inChorus = false;
+      for (const ln of lines) {
+        const trimmed = ln.trim();
+        if (/^\{title\s*:/.test(trimmed)) {
+          const m = trimmed.match(/^\{title\s*:\s*(.*?)\s*\}/i);
+          out.push(`<h3 class="pv-title">${esc(m ? m[1] : '')}</h3>`);
+          continue;
+        }
+        if (/^\{(comment|artist|author|key|capo)\s*:/.test(trimmed)) {
+          const m = trimmed.match(/^\{(\w+)\s*:\s*(.*?)\s*\}/i);
+          out.push(`<div class="pv-meta">${m ? esc(m[1] + ': ' + m[2]) : esc(trimmed)}</div>`);
+          continue;
+        }
+        if (/^\{soc\}/.test(trimmed)) { inChorus = true; out.push('<div class="pv-chorus">'); continue; }
+        if (/^\{eoc\}/.test(trimmed)) { inChorus = false; out.push('</div>'); continue; }
+        if (trimmed === '') { out.push('<div class="pv-blank"></div>'); continue; }
+        out.push(`<div class="pv-line">${renderChordLine(ln)}</div>`);
+      }
+      if (inChorus) out.push('</div>');
+      return out.join('\n');
+    },
+  };
+}
+
+// Render a ChordPro line: produces stacked chord/lyric HTML.
+function renderChordLine(line) {
+  const esc = (s) => String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+  // Tokenize: each [chord] or character
+  const tokens = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '[') {
+      const j = line.indexOf(']', i);
+      if (j > 0) {
+        tokens.push({ chord: line.slice(i + 1, j) });
+        i = j + 1;
+        continue;
+      }
+    }
+    tokens.push({ char: line[i] });
+    i++;
+  }
+  // Group: each pos has [chords...] + chars until next chord
+  const html = [];
+  let pendingChords = [];
+  let textBuf = '';
+  for (const t of tokens) {
+    if (t.chord != null) {
+      // flush previous segment first
+      if (textBuf || pendingChords.length) {
+        html.push(`<span class="pv-seg"><span class="pv-chords">${pendingChords.map(esc).join(' ')}</span><span class="pv-lyr">${esc(textBuf) || '&nbsp;'}</span></span>`);
+        pendingChords = [];
+        textBuf = '';
+      }
+      pendingChords.push('[' + t.chord + ']');
+    } else {
+      textBuf += t.char;
+    }
+  }
+  if (textBuf || pendingChords.length) {
+    html.push(`<span class="pv-seg"><span class="pv-chords">${pendingChords.map(esc).join(' ')}</span><span class="pv-lyr">${esc(textBuf) || '&nbsp;'}</span></span>`);
+  }
+  return html.join('');
+}

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -41,7 +41,10 @@ function app() {
       dirty: false,
       tab: 'raw',
       meta: { title: '', artist: '', key: '', capo: 0, has_todo: false },
+      parsed: [],
     },
+    visualAddMode: false,
+    visualSelectedChord: null,  // {lineIdx, chordIdx}
 
     // ─────────── Lifecycle ───────────
     async boot() {
@@ -216,7 +219,198 @@ function app() {
         meta: { title: '', artist: '', key: '', capo: 0, has_todo: false },
       };
     },
-    setEditorTab(t) { this.editor.tab = t; },
+    setEditorTab(t) {
+      // Sincronizar entre tabs según la dirección
+      if (this.editor.tab === 'visual' && t !== 'visual') {
+        // visual → otro: serializar parsed → content
+        this.editor.content = serializeCho(this.editor.parsed);
+        this.refreshMetaFromRaw();
+      }
+      this.editor.tab = t;
+      if (t === 'visual') {
+        // raw → visual: parsear content
+        this.editor.parsed = parseCho(this.editor.content);
+        this.$nextTick(() => this.layoutChords());
+      }
+    },
+
+    // ─────────── Editor visual ───────────
+    layoutChords() {
+      const root = document.querySelector('.visual-doc');
+      if (!root) return;
+      const lines = root.querySelectorAll('.ed-line');
+      lines.forEach((lineEl) => {
+        const idx = parseInt(lineEl.dataset.lineIdx, 10);
+        const ln = this.editor.parsed[idx];
+        if (!ln || ln.type !== 'lyric') return;
+        const layer = lineEl.querySelector('.ed-chords-layer');
+        if (!layer) return;
+        layer.innerHTML = '';
+        const lyricRow = lineEl.querySelector('.ed-lyric-row');
+        const lyricRect = lyricRow.getBoundingClientRect();
+        const chars = lyricRow.querySelectorAll('.ed-char');
+        ln.chords.forEach((ch, chordIdx) => {
+          const target = chars[Math.min(ch.pos, chars.length - 1)] || chars[chars.length - 1];
+          if (!target) return;
+          const t = target.getBoundingClientRect();
+          const left = t.left - lyricRect.left;
+          const el = document.createElement('span');
+          el.className = 'ed-chord';
+          el.dataset.lineIdx = idx;
+          el.dataset.chordIdx = chordIdx;
+          el.style.left = left + 'px';
+          el.textContent = ch.text;
+          if (this.visualSelectedChord &&
+              this.visualSelectedChord.lineIdx === idx &&
+              this.visualSelectedChord.chordIdx === chordIdx) {
+            el.classList.add('selected');
+          }
+          this.attachChordEvents(el);
+          layer.appendChild(el);
+        });
+      });
+    },
+
+    attachChordEvents(el) {
+      const self = this;
+      let dragState = null;
+
+      el.addEventListener('mousedown', (ev) => {
+        if (ev.button !== 0) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        const lineIdx = parseInt(el.dataset.lineIdx, 10);
+        const chordIdx = parseInt(el.dataset.chordIdx, 10);
+        self.visualSelectedChord = { lineIdx, chordIdx };
+        // Refresh selection visuals
+        document.querySelectorAll('.ed-chord.selected').forEach(n => n.classList.remove('selected'));
+        el.classList.add('selected');
+        // Focus root for keyboard
+        const root = document.querySelector('.visual-doc');
+        if (root) root.focus();
+
+        const startX = ev.clientX;
+        const startLeft = parseFloat(el.style.left) || 0;
+        dragState = { startX, startLeft, lineIdx, chordIdx, moved: false };
+
+        function onMove(e) {
+          if (!dragState) return;
+          const dx = e.clientX - dragState.startX;
+          if (Math.abs(dx) > 3) dragState.moved = true;
+          el.style.left = (dragState.startLeft + dx) + 'px';
+          el.classList.add('dragging');
+        }
+        function onUp(e) {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+          el.classList.remove('dragging');
+          if (!dragState || !dragState.moved) {
+            dragState = null;
+            return;
+          }
+          // Find closest char in this line
+          const lineEl = document.querySelector(`.ed-line[data-line-idx="${dragState.lineIdx}"]`);
+          const lyricRow = lineEl && lineEl.querySelector('.ed-lyric-row');
+          if (!lyricRow) { dragState = null; return; }
+          const chars = lyricRow.querySelectorAll('.ed-char');
+          let bestIdx = 0, bestDist = Infinity;
+          const dropX = e.clientX;
+          chars.forEach((c, i) => {
+            const r = c.getBoundingClientRect();
+            const cx = r.left + r.width / 2;
+            const d = Math.abs(cx - dropX);
+            if (d < bestDist) { bestDist = d; bestIdx = i; }
+          });
+          // Word-start snap unless Shift held
+          if (!e.shiftKey) {
+            const ln = self.editor.parsed[dragState.lineIdx];
+            bestIdx = snapToWordStart(bestIdx, ln.lyric);
+          }
+          const ln = self.editor.parsed[dragState.lineIdx];
+          ln.chords[dragState.chordIdx].pos = bestIdx;
+          self.editor.dirty = true;
+          self.editor.content = serializeCho(self.editor.parsed);
+          self.refreshMetaFromRaw();
+          self.layoutChords();
+          dragState = null;
+        }
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      });
+
+      el.addEventListener('dblclick', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const lineIdx = parseInt(el.dataset.lineIdx, 10);
+        const chordIdx = parseInt(el.dataset.chordIdx, 10);
+        const cur = self.editor.parsed[lineIdx].chords[chordIdx].text;
+        const next = prompt('Acorde:', cur);
+        if (next != null) {
+          const v = next.trim();
+          if (v === '') {
+            // delete
+            self.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
+          } else {
+            self.editor.parsed[lineIdx].chords[chordIdx].text = v;
+          }
+          self.editor.dirty = true;
+          self.editor.content = serializeCho(self.editor.parsed);
+          self.refreshMetaFromRaw();
+          self.layoutChords();
+        }
+      });
+
+      el.addEventListener('contextmenu', (ev) => {
+        ev.preventDefault();
+        const lineIdx = parseInt(el.dataset.lineIdx, 10);
+        const chordIdx = parseInt(el.dataset.chordIdx, 10);
+        if (confirm('¿Borrar este acorde?')) {
+          self.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
+          self.editor.dirty = true;
+          self.editor.content = serializeCho(self.editor.parsed);
+          self.refreshMetaFromRaw();
+          self.layoutChords();
+        }
+      });
+    },
+
+    onVisualClick(ev) {
+      // Add chord on click when add mode is on
+      if (!this.visualAddMode) {
+        // Click outside chord → deselect
+        if (!ev.target.classList.contains('ed-chord')) {
+          this.visualSelectedChord = null;
+          document.querySelectorAll('.ed-chord.selected').forEach(n => n.classList.remove('selected'));
+        }
+        return;
+      }
+      const charEl = ev.target.closest('.ed-char');
+      if (!charEl) return;
+      const lineEl = charEl.closest('.ed-line');
+      const lineIdx = parseInt(lineEl.dataset.lineIdx, 10);
+      const charIdx = parseInt(charEl.dataset.idx, 10);
+      const text = prompt('Acorde nuevo:', 'C');
+      if (!text || !text.trim()) return;
+      this.editor.parsed[lineIdx].chords.push({ text: text.trim(), pos: charIdx });
+      this.editor.parsed[lineIdx].chords.sort((a, b) => a.pos - b.pos);
+      this.editor.dirty = true;
+      this.editor.content = serializeCho(this.editor.parsed);
+      this.refreshMetaFromRaw();
+      this.visualAddMode = false;
+      this.$nextTick(() => this.layoutChords());
+    },
+
+    deleteSelectedChord() {
+      if (!this.visualSelectedChord) return;
+      const { lineIdx, chordIdx } = this.visualSelectedChord;
+      this.editor.parsed[lineIdx].chords.splice(chordIdx, 1);
+      this.editor.dirty = true;
+      this.editor.content = serializeCho(this.editor.parsed);
+      this.refreshMetaFromRaw();
+      this.visualSelectedChord = null;
+      this.layoutChords();
+    },
+
     refreshMetaFromRaw() {
       const c = this.editor.content;
       const get = (k) => {
@@ -338,6 +532,91 @@ function app() {
     },
   };
 }
+
+// ─────────── ChordPro parsing helpers (visual editor) ───────────
+
+// Parse full ChordPro content into a list of line-objects.
+// Types: 'directive' (incl. {comment}), 'soc', 'eoc', 'blank', 'lyric'.
+function parseCho(content) {
+  const lines = content.split('\n');
+  return lines.map(raw => {
+    const t = raw.trim();
+    if (t === '') return { type: 'blank', raw };
+    if (/^\{soc\}$/i.test(t) || /^\{start_of_chorus\}$/i.test(t)) return { type: 'soc', raw };
+    if (/^\{eoc\}$/i.test(t) || /^\{end_of_chorus\}$/i.test(t)) return { type: 'eoc', raw };
+    if (/^\{[a-z_]+\s*:/i.test(t) || /^\{[a-z_]+\}$/i.test(t)) {
+      const isComment = /^\{comment/i.test(t);
+      return { type: isComment ? 'comment' : 'directive', raw };
+    }
+    // Parse as lyric line with optional [chord] tags
+    const { lyric, chords } = parseChordLineToModel(raw);
+    return { type: 'lyric', lyric, chords, raw };
+  });
+}
+
+function parseChordLineToModel(line) {
+  let lyric = '';
+  const chords = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '[') {
+      const j = line.indexOf(']', i);
+      if (j > 0) {
+        chords.push({ text: line.slice(i + 1, j), pos: lyric.length });
+        i = j + 1;
+        continue;
+      }
+    }
+    lyric += line[i];
+    i++;
+  }
+  return { lyric, chords };
+}
+
+function serializeChordLine(model) {
+  // Insert chords back into the lyric at their positions; multiple chords at the same pos stack.
+  const lyric = model.lyric;
+  const byPos = new Map();
+  for (const ch of model.chords) {
+    const p = Math.max(0, Math.min(ch.pos, lyric.length));
+    if (!byPos.has(p)) byPos.set(p, []);
+    byPos.get(p).push(ch.text);
+  }
+  const positions = [...byPos.keys()].sort((a, b) => a - b);
+  let out = '';
+  let last = 0;
+  for (const p of positions) {
+    out += lyric.slice(last, p);
+    for (const t of byPos.get(p)) out += '[' + t + ']';
+    last = p;
+  }
+  out += lyric.slice(last);
+  return out;
+}
+
+function serializeCho(parsed) {
+  return parsed.map(ln => {
+    if (ln.type === 'lyric') return serializeChordLine({ lyric: ln.lyric, chords: ln.chords });
+    return ln.raw;
+  }).join('\n');
+}
+
+function snapToWordStart(idx, lyric) {
+  // Find the word-start (non-space preceded by space or BOL) closest in CHARS to idx.
+  if (!lyric) return idx;
+  const starts = [0];
+  for (let i = 1; i < lyric.length; i++) {
+    if (!isSpace(lyric[i]) && isSpace(lyric[i - 1])) starts.push(i);
+  }
+  starts.push(lyric.length);
+  let best = starts[0], bestDist = Infinity;
+  for (const s of starts) {
+    const d = Math.abs(s - idx);
+    if (d < bestDist) { bestDist = d; best = s; }
+  }
+  return best;
+}
+function isSpace(ch) { return ch === ' ' || ch === '\t'; }
 
 // Render a ChordPro line: produces stacked chord/lyric HTML.
 function renderChordLine(line) {

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -276,10 +276,52 @@
           </div>
         </div>
 
-        <!-- VISUAL (3c) - placeholder for now -->
-        <div class="editor-pane" x-show="editor.tab === 'visual'" x-cloak>
-          <div class="placeholder">
-            🚧 Editor visual con drag&drop — próxima fase. Usa la pestaña <em>Raw</em> mientras tanto.
+        <!-- VISUAL -->
+        <div class="editor-pane visual" x-show="editor.tab === 'visual'" x-cloak>
+          <div class="visual-toolbar">
+            <button class="btn-mini" @click="visualAddMode = !visualAddMode"
+                    :class="{primary: visualAddMode}">
+              <span x-text="visualAddMode ? '✕ Cancelar añadir' : '+ Añadir acorde'"></span>
+            </button>
+            <span class="hint">
+              Arrastra acordes para moverlos · doble-click para editar texto ·
+              tecla <kbd>Supr</kbd> para borrar · <kbd>Shift</kbd> al soltar = sin snap.
+              <span x-show="visualAddMode" class="adding-hint">Modo añadir: pincha una letra para colocar un acorde nuevo.</span>
+            </span>
+          </div>
+          <div class="visual-doc"
+               @click="onVisualClick($event)"
+               @keydown.delete.prevent="deleteSelectedChord()"
+               @keydown.backspace.prevent="deleteSelectedChord()"
+               tabindex="0">
+            <template x-for="(ln, idx) in editor.parsed" :key="idx">
+              <div :class="'ed-line ed-' + ln.type" :data-line-idx="idx">
+                <!-- meta / directives shown as compact tags -->
+                <template x-if="ln.type === 'directive' || ln.type === 'comment'">
+                  <div class="ed-meta-line" x-text="ln.raw"></div>
+                </template>
+                <template x-if="ln.type === 'soc'">
+                  <div class="ed-marker">▶ Inicio estribillo</div>
+                </template>
+                <template x-if="ln.type === 'eoc'">
+                  <div class="ed-marker">◀ Fin estribillo</div>
+                </template>
+                <template x-if="ln.type === 'blank'">
+                  <div class="ed-blank">·</div>
+                </template>
+                <template x-if="ln.type === 'lyric'">
+                  <div class="ed-line-row">
+                    <div class="ed-chords-layer"></div>
+                    <div class="ed-lyric-row">
+                      <template x-for="(ch, i) in ln.lyric" :key="i">
+                        <span class="ed-char" :data-idx="i" x-text="ch === ' ' ? ' ' : ch"></span>
+                      </template>
+                      <span class="ed-char ed-end" :data-idx="ln.lyric.length">⏎</span>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </template>
           </div>
         </div>
 

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -14,7 +14,7 @@
     <div class="brand-emoji">🎵</div>
     <div>
       <div class="brand-title">Cantoral Admin</div>
-      <div class="brand-sub">MCM Castellón</div>
+      <div class="brand-sub">Familia Consolación</div>
     </div>
   </div>
 
@@ -48,6 +48,12 @@
 
 <main>
 
+  <!-- TOP BAR: indicador de guardado global -->
+  <div class="topbar">
+    <div class="save-indicator" :class="saveIndicator.cls" x-text="saveIndicator.text"></div>
+    <button class="topbar-help" @click="showHelp = true" title="Ayuda y atajos">❓</button>
+  </div>
+
   <!-- LOADING -->
   <div x-show="loading && !data" class="loading">Cargando catálogo…</div>
   <div x-show="error" class="error" x-text="error"></div>
@@ -80,13 +86,21 @@
     <div class="actions-row">
       <button class="btn primary" @click="view = 'import'">📥 Importar del cantoral</button>
       <button class="btn" @click="view = 'catalog'; todoFilter = true">📝 Ver pendientes de revisión</button>
-      <button class="btn" @click="buildJson()" :disabled="building">
-        <span x-show="!building">🔨 Regenerar songs.json</span>
-        <span x-show="building">Generando…</span>
-      </button>
+      <button class="btn" @click="openNewSongModal()">➕ Nueva canción a mano</button>
     </div>
-    <div x-show="buildResult" class="output" x-cloak>
-      <pre x-text="buildResult"></pre>
+
+    <div class="commit-reminder">
+      <h3>🚀 Cómo publicar tus cambios</h3>
+      <p>
+        Esta app guarda directamente en los archivos <code>.cho</code> del repositorio.
+        Cuando hayas terminado de editar, haz un <code>git commit</code> y un
+        <code>git push</code> a la rama. Un GitHub Action se encarga automáticamente
+        de regenerar <code>songs-vX.json</code> y subirlo a Firebase.
+      </p>
+      <p class="muted">
+        En la terminal, desde la raíz del repo:
+        <code>git add songs/ &amp;&amp; git commit -m "..." &amp;&amp; git push</code>
+      </p>
     </div>
   </section>
 
@@ -335,6 +349,99 @@
         <!-- PREVIEW -->
         <div class="editor-pane preview" x-show="editor.tab === 'preview'" x-cloak>
           <div class="preview-render" x-html="renderPreviewHtml(editor.content)"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- HELP MODAL -->
+  <div class="editor-overlay" x-show="showHelp" @click.self="showHelp = false" x-cloak>
+    <div class="editor-modal small">
+      <div class="editor-header">
+        <h2>❓ Atajos y trucos</h2>
+        <button class="btn" @click="showHelp = false">✕ Cerrar</button>
+      </div>
+      <div class="editor-body single">
+        <div class="editor-pane" style="overflow:auto">
+          <h3>Editor visual</h3>
+          <table class="kbd-help">
+            <tr><th>Arrastrar acorde</th><td>Mueve el acorde. Al soltar hace <em>snap</em> al inicio de palabra más cercano.</td></tr>
+            <tr><th><kbd>Shift</kbd> + soltar</th><td>Snap por <strong>sílaba</strong> (cómo se canta).</td></tr>
+            <tr><th><kbd>Alt</kbd> + soltar</th><td>Sin snap — colocación carácter a carácter (pixel perfect).</td></tr>
+            <tr><th>Doble-click acorde</th><td>Edita texto del acorde (vacío = borrar).</td></tr>
+            <tr><th>Click derecho acorde</th><td>Borra con confirmación.</td></tr>
+            <tr><th><kbd>Supr</kbd></th><td>Borra el acorde seleccionado.</td></tr>
+            <tr><th>Doble-click en letra</th><td>Edita el texto de esa línea entera.</td></tr>
+            <tr><th>Click en margen izq.</th><td>Selecciona la línea (verde). Útil para marcar estribillos o copiar acordes.</td></tr>
+            <tr><th><kbd>Shift</kbd>+click en margen</th><td>Selección de rango.</td></tr>
+          </table>
+          <h3>Marcar estribillo</h3>
+          <ol>
+            <li>Selecciona las líneas (clicks en el margen izquierdo).</li>
+            <li>Pulsa <strong>"Marcar estribillo"</strong> en la barra del editor.</li>
+            <li>Para quitar marcadores, pulsa <strong>"Quitar marcadores"</strong>.</li>
+          </ol>
+          <h3>Copiar / pegar estribillo</h3>
+          <p>Botón <strong>"Insertar estribillo"</strong> → elige cuál de los estribillos ya marcados quieres pegar; se inserta justo después de la línea actualmente seleccionada (o al final).</p>
+          <h3>Copiar patrón de acordes entre estrofas</h3>
+          <ol>
+            <li>Selecciona las líneas de la estrofa con los acordes que quieres copiar.</li>
+            <li>Pulsa <strong>"Copiar acordes"</strong>.</li>
+            <li>Selecciona las líneas destino (sin acordes o con pocos).</li>
+            <li>Pulsa <strong>"Pegar acordes"</strong>. Se alinean por <em>palabra</em>: el acorde N de la línea origen va a la palabra N de la línea destino. Luego ajusta a mano lo que haga falta.</li>
+          </ol>
+          <h3>Guardado</h3>
+          <p>La app escribe directamente en los archivos <code>.cho</code>. Cuando termines, haz <code>git commit</code> y <code>git push</code> — un GitHub Action regenera <code>songs.json</code> y lo sube a Firebase automáticamente.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- NEW SONG MODAL -->
+  <div class="editor-overlay" x-show="newSong.open" @click.self="newSong.open = false" x-cloak>
+    <div class="editor-modal small">
+      <div class="editor-header">
+        <h2>➕ Nueva canción</h2>
+        <button class="btn" @click="newSong.open = false">✕ Cerrar</button>
+      </div>
+      <div class="editor-body single">
+        <div class="editor-pane" style="overflow:auto">
+          <div class="form-grid">
+            <label>Categoría</label>
+            <select x-model="newSong.category">
+              <option value="">— Elige —</option>
+              <template x-for="cat in (data ? data.categories : [])" :key="cat.letter">
+                <option :value="cat.letter" x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '')"></option>
+              </template>
+            </select>
+            <label>Título</label>
+            <input type="text" x-model="newSong.title" placeholder="Ven a celebrar" />
+            <label>Autor / Artista</label>
+            <input type="text" x-model="newSong.artist" />
+            <label>Tono</label>
+            <input type="text" x-model="newSong.key" placeholder="G" />
+            <label>Capo</label>
+            <input type="number" min="0" x-model="newSong.capo" />
+            <label>Modo</label>
+            <select x-model="newSong.mode">
+              <option value="blank">En blanco (rellenas en el editor)</option>
+              <option value="chordpro">Pego un .cho en formato ChordPro</option>
+              <option value="ug" disabled>📌 Pegar formato Ultimate Guitar (próximamente)</option>
+              <option value="word" disabled>📌 Pegar texto con acordes encima en líneas separadas (próximamente)</option>
+            </select>
+            <label x-show="newSong.mode === 'chordpro'">Contenido ChordPro</label>
+            <textarea x-show="newSong.mode === 'chordpro'" x-model="newSong.content" rows="10"
+                      placeholder="{title: ...}&#10;[C]Letra de la canción..."></textarea>
+          </div>
+          <p class="muted small">
+            La nueva canción se guarda con
+            <code>{comment: TO DO: PENDIENTE REVISIÓN ACORDES}</code> al inicio, para que la revises
+            con el editor visual (badge 📝 en el catálogo).
+          </p>
+          <div class="actions-row">
+            <button class="btn primary" :disabled="!newSong.category || !newSong.title || newSong.creating"
+                    @click="createNewSong()" x-text="newSong.creating ? 'Creando…' : 'Crear y abrir editor'"></button>
+          </div>
         </div>
       </div>
     </div>

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Cantoral Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="stylesheet" href="style.css" />
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
+</head>
+<body x-data="app()" x-init="boot()" :class="{ 'theme-dark': theme === 'dark' }">
+
+<aside class="sidebar">
+  <div class="brand">
+    <div class="brand-emoji">🎵</div>
+    <div>
+      <div class="brand-title">Cantoral Admin</div>
+      <div class="brand-sub">MCM Castellón</div>
+    </div>
+  </div>
+
+  <nav>
+    <a :class="{active: view === 'dashboard'}" @click.prevent="view = 'dashboard'" href="#">📊 Dashboard</a>
+    <a :class="{active: view === 'catalog'}" @click.prevent="view = 'catalog'; categoryFilter = ''" href="#">📋 Catálogo</a>
+    <a :class="{active: view === 'import'}" @click.prevent="view = 'import'" href="#">📥 Importar del cantoral</a>
+    <a :class="{active: view === 'reorder'}" @click.prevent="view = 'reorder'" href="#">🔀 Reordenar</a>
+  </nav>
+
+  <div class="sidebar-section" x-show="data">
+    <div class="sidebar-section-title">Categorías</div>
+    <template x-for="cat in (data ? data.categories : [])" :key="cat.letter">
+      <a class="cat-link" href="#"
+         @click.prevent="view = 'catalog'; categoryFilter = cat.letter"
+         :class="{active: categoryFilter === cat.letter && view === 'catalog'}">
+        <span class="cat-letter" x-text="cat.letter"></span>
+        <span class="cat-name" x-text="cat.title.replace(/^[A-Z+\d]+\.\s*/, '')"></span>
+        <span class="cat-count" x-text="countByCat(cat.letter)"></span>
+      </a>
+    </template>
+  </div>
+
+  <div class="sidebar-foot">
+    <button @click="theme = theme === 'dark' ? 'light' : 'dark'; localStorage.theme = theme">
+      <span x-text="theme === 'dark' ? '☀️ Claro' : '🌙 Oscuro'"></span>
+    </button>
+    <button @click="loadCatalog()" :disabled="loading">🔄 Recargar</button>
+  </div>
+</aside>
+
+<main>
+
+  <!-- LOADING -->
+  <div x-show="loading && !data" class="loading">Cargando catálogo…</div>
+  <div x-show="error" class="error" x-text="error"></div>
+
+  <!-- DASHBOARD -->
+  <section x-show="view === 'dashboard' && data" x-cloak>
+    <h1>📊 Dashboard</h1>
+    <div class="stats-grid">
+      <div class="stat">
+        <div class="stat-val" x-text="data.stats.repo_total"></div>
+        <div class="stat-lbl">canciones en el repo</div>
+      </div>
+      <div class="stat">
+        <div class="stat-val" x-text="data.stats.docx_total"></div>
+        <div class="stat-lbl">canciones en el cantoral</div>
+      </div>
+      <div class="stat warn">
+        <div class="stat-val" x-text="data.stats.missing_from_repo"></div>
+        <div class="stat-lbl">faltan en el repo</div>
+      </div>
+      <div class="stat todo">
+        <div class="stat-val" x-text="data.stats.todo_count"></div>
+        <div class="stat-lbl">con TO DO pendiente</div>
+      </div>
+      <div class="stat info">
+        <div class="stat-val" x-text="data.stats.only_in_repo"></div>
+        <div class="stat-lbl">solo en repo (manuales)</div>
+      </div>
+    </div>
+    <div class="actions-row">
+      <button class="btn primary" @click="view = 'import'">📥 Importar del cantoral</button>
+      <button class="btn" @click="view = 'catalog'; todoFilter = true">📝 Ver pendientes de revisión</button>
+      <button class="btn" @click="buildJson()" :disabled="building">
+        <span x-show="!building">🔨 Regenerar songs.json</span>
+        <span x-show="building">Generando…</span>
+      </button>
+    </div>
+    <div x-show="buildResult" class="output" x-cloak>
+      <pre x-text="buildResult"></pre>
+    </div>
+  </section>
+
+  <!-- CATÁLOGO -->
+  <section x-show="view === 'catalog' && data" x-cloak>
+    <h1>📋 Catálogo
+      <span x-show="categoryFilter" class="filter-tag" x-text="'· ' + categoryName(categoryFilter)"></span>
+    </h1>
+
+    <div class="filter-bar">
+      <input type="search" placeholder="Buscar título o autor…" x-model="search" />
+      <label><input type="checkbox" x-model="todoFilter" /> Solo TO DO</label>
+      <label><input type="checkbox" x-model="onlyInRepoFilter" /> Solo manuales (no en cantoral)</label>
+      <button @click="search = ''; todoFilter = false; onlyInRepoFilter = false; categoryFilter = ''">Limpiar</button>
+      <span class="count" x-text="filteredRepoSongs().length + ' canciones'"></span>
+    </div>
+
+    <table class="songs">
+      <thead>
+        <tr>
+          <th></th>
+          <th>#</th>
+          <th>Título</th>
+          <th>Autor</th>
+          <th>Tono</th>
+          <th>Capo</th>
+          <th>Categoría</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="r in filteredRepoSongs()" :key="r.path">
+          <tr>
+            <td>
+              <span class="badge ok" x-show="r.in_docx" title="También en el cantoral">✅</span>
+              <span class="badge info" x-show="!r.in_docx" title="Solo en repo (manual)">➕</span>
+              <span class="badge todo" x-show="r.has_todo" title="TO DO pendiente revisión">📝</span>
+            </td>
+            <td x-text="r.number"></td>
+            <td><a href="#" @click.prevent="openEditor(r.path)" x-text="r.title"></a></td>
+            <td x-text="r.artist"></td>
+            <td x-text="r.key"></td>
+            <td x-text="r.capo || ''"></td>
+            <td x-text="r.category_letter + '. ' + r.category_folder.replace(/^[A-Z+\d]+\.\s*/, '')"></td>
+            <td>
+              <button class="btn-mini" @click="openEditor(r.path)">Editar</button>
+              <button class="btn-mini danger" @click="deleteSong(r)">Borrar</button>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- IMPORTAR -->
+  <section x-show="view === 'import' && data" x-cloak>
+    <h1>📥 Importar del cantoral</h1>
+    <p class="muted">
+      Canciones del Word que <strong>aún no existen</strong> en <code>/songs/</code>.
+      Al importar, se guarda con la línea <code>{comment: TO DO: PENDIENTE REVISIÓN ACORDES}</code>
+      al principio para que las revises (mostrarán <span class="badge todo">📝</span>).
+    </p>
+
+    <div class="filter-bar">
+      <input type="search" placeholder="Buscar…" x-model="importSearch" />
+      <select x-model="importSectionFilter">
+        <option value="">Todas las secciones</option>
+        <template x-for="cat in data.categories" :key="cat.letter">
+          <option :value="cat.letter" x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '')"></option>
+        </template>
+      </select>
+      <button @click="selectAllImport()">Seleccionar todas</button>
+      <button @click="selectedImports = new Set()">Limpiar selección</button>
+      <button class="btn primary" :disabled="selectedImports.size === 0 || importing"
+              @click="doImport()"
+              x-text="importing ? 'Importando…' : `Importar ${selectedImports.size} seleccionadas`"></button>
+    </div>
+
+    <table class="songs">
+      <thead>
+        <tr><th></th><th>Sección</th><th>Título (en el docx)</th><th>Tono</th><th>Capo</th><th>Avisos</th><th></th></tr>
+      </thead>
+      <tbody>
+        <template x-for="m in filteredMissing()" :key="m.docx_id">
+          <tr :class="{ 'has-warn': m.warnings.length > 0 }">
+            <td>
+              <input type="checkbox"
+                     :checked="selectedImports.has(m.docx_id)"
+                     @change="toggleImport(m.docx_id)" />
+            </td>
+            <td x-text="m.section_letter"></td>
+            <td><a href="#" @click.prevent="previewDocx(m.docx_id)" x-text="m.title"></a></td>
+            <td x-text="m.key"></td>
+            <td x-text="m.capo || ''"></td>
+            <td class="warn-cell" x-text="m.warnings.join('; ')"></td>
+            <td><button class="btn-mini" @click="previewDocx(m.docx_id)">👁 Ver</button></td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+
+    <div x-show="importResults.length > 0" class="import-results" x-cloak>
+      <h3>Resultado:</h3>
+      <ul>
+        <template x-for="r in importResults" :key="r.id">
+          <li :class="{ ok: r.ok, err: !r.ok }">
+            <span x-text="r.ok ? '✓' : '✗'"></span>
+            <span x-text="r.title || `id ${r.id}`"></span>
+            <span x-show="r.path" class="path" x-text="r.path"></span>
+            <span x-show="r.error" class="error-msg" x-text="r.error"></span>
+          </li>
+        </template>
+      </ul>
+    </div>
+  </section>
+
+  <!-- REORDENAR -->
+  <section x-show="view === 'reorder' && data" x-cloak>
+    <h1>🔀 Reordenar canciones</h1>
+    <p class="muted">Elige una categoría, arrastra para reordenar y pulsa <em>Aplicar</em>. Los archivos
+       se renumerarán (<code>01., 02., …</code>) manteniendo el slug. Se hace backup en
+       <code>songs-backup-edits/</code>.</p>
+    <div class="filter-bar">
+      <select x-model="reorderCategory" @change="loadReorder()">
+        <option value="">— Elige categoría —</option>
+        <template x-for="cat in data.categories" :key="cat.letter">
+          <option :value="cat.letter" x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '')"></option>
+        </template>
+      </select>
+      <button class="btn primary" :disabled="!reorderModified" @click="applyReorder()">Aplicar nuevo orden</button>
+      <button x-show="reorderModified" @click="loadReorder()">Cancelar cambios</button>
+    </div>
+
+    <ul class="reorder-list" x-show="reorderCategory">
+      <template x-for="(s, idx) in reorderSongs" :key="s.path">
+        <li draggable="true"
+            @dragstart="reorderDragIdx = idx"
+            @dragover.prevent
+            @drop="onReorderDrop(idx)">
+          <span class="grip">⋮⋮</span>
+          <span class="new-num" x-text="(idx + 1).toString().padStart(2,'0')"></span>
+          <span class="old-num" x-text="s.number != null ? `(was ${s.number.toString().padStart(2,'0')})` : ''"></span>
+          <span class="title" x-text="s.title"></span>
+          <span class="filename" x-text="s.filename"></span>
+        </li>
+      </template>
+    </ul>
+  </section>
+
+  <!-- EDITOR MODAL -->
+  <div class="editor-overlay" x-show="editor.path" @click.self="closeEditor()" x-cloak>
+    <div class="editor-modal">
+      <div class="editor-header">
+        <h2>
+          <span x-text="editor.meta.title || editor.filename"></span>
+          <span class="badge todo" x-show="editor.meta.has_todo">📝 TO DO</span>
+        </h2>
+        <div class="editor-actions">
+          <button x-show="editor.meta.has_todo" class="btn" @click="markReviewed()">✓ Revisada</button>
+          <button class="btn primary" :disabled="!editor.dirty" @click="saveSong()">💾 Guardar</button>
+          <button class="btn" @click="closeEditor()">✕ Cerrar</button>
+        </div>
+      </div>
+
+      <div class="editor-tabs">
+        <button :class="{active: editor.tab === 'visual'}" @click="setEditorTab('visual')">🎨 Visual</button>
+        <button :class="{active: editor.tab === 'raw'}" @click="setEditorTab('raw')">📝 Raw</button>
+        <button :class="{active: editor.tab === 'preview'}" @click="setEditorTab('preview')">👁 Preview</button>
+        <span class="dirty" x-show="editor.dirty">● sin guardar</span>
+      </div>
+
+      <div class="editor-body">
+
+        <!-- METADATA SIDE PANEL (always visible) -->
+        <div class="editor-meta">
+          <h4>Metadatos</h4>
+          <label>Título</label>
+          <input type="text" x-model="editor.meta.title" @input="updateMetaInRaw('title', $event.target.value)" />
+          <label>Autor / Artista</label>
+          <input type="text" x-model="editor.meta.artist" @input="updateMetaInRaw('artist', $event.target.value)" />
+          <label>Tono (key)</label>
+          <input type="text" x-model="editor.meta.key" @input="updateMetaInRaw('key', $event.target.value)" />
+          <label>Capo</label>
+          <input type="number" min="0" x-model="editor.meta.capo" @input="updateMetaInRaw('capo', $event.target.value)" />
+          <div class="path-info">
+            <small x-text="editor.path"></small>
+          </div>
+        </div>
+
+        <!-- VISUAL (3c) - placeholder for now -->
+        <div class="editor-pane" x-show="editor.tab === 'visual'" x-cloak>
+          <div class="placeholder">
+            🚧 Editor visual con drag&drop — próxima fase. Usa la pestaña <em>Raw</em> mientras tanto.
+          </div>
+        </div>
+
+        <!-- RAW -->
+        <div class="editor-pane raw" x-show="editor.tab === 'raw'" x-cloak>
+          <textarea x-model="editor.content"
+                    @input="editor.dirty = true; refreshMetaFromRaw()"
+                    spellcheck="false"></textarea>
+        </div>
+
+        <!-- PREVIEW -->
+        <div class="editor-pane preview" x-show="editor.tab === 'preview'" x-cloak>
+          <div class="preview-render" x-html="renderPreviewHtml(editor.content)"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DOCX PREVIEW MODAL -->
+  <div class="editor-overlay" x-show="docxPreview" @click.self="docxPreview = null" x-cloak>
+    <div class="editor-modal small">
+      <div class="editor-header">
+        <h2 x-text="docxPreview ? docxPreview.title : ''"></h2>
+        <div class="editor-actions">
+          <button class="btn primary" @click="importOne(docxPreview.id)">Importar esta</button>
+          <button class="btn" @click="docxPreview = null">✕ Cerrar</button>
+        </div>
+      </div>
+      <div class="editor-body single">
+        <div class="editor-pane preview">
+          <pre x-text="docxPreview ? docxPreview.content : ''"></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -295,40 +295,72 @@
           <div class="visual-toolbar">
             <button class="btn-mini" @click="visualAddMode = !visualAddMode"
                     :class="{primary: visualAddMode}">
-              <span x-text="visualAddMode ? '✕ Cancelar añadir' : '+ Añadir acorde'"></span>
+              <span x-text="visualAddMode ? '✕ Cancelar añadir' : '+ Acorde'"></span>
             </button>
-            <span class="hint">
-              Arrastra acordes para moverlos · doble-click para editar texto ·
-              tecla <kbd>Supr</kbd> para borrar · <kbd>Shift</kbd> al soltar = sin snap.
-              <span x-show="visualAddMode" class="adding-hint">Modo añadir: pincha una letra para colocar un acorde nuevo.</span>
-            </span>
+
+            <span class="sep"></span>
+            <span class="sel-info" x-show="visualSelectedLines.size > 0"
+                  x-text="visualSelectedLines.size + ' línea(s) sel.'"></span>
+            <button class="btn-mini" :disabled="visualSelectedLines.size === 0"
+                    @click="markSelectionAsChorus()">🟡 Marcar estribillo</button>
+            <button class="btn-mini" :disabled="visualSelectedLines.size === 0"
+                    @click="unmarkSelectionChorus()">Quitar marca</button>
+
+            <span class="sep"></span>
+            <button class="btn-mini" :disabled="visualSelectedLines.size === 0"
+                    @click="copyChordPattern()">📋 Copiar acordes</button>
+            <button class="btn-mini"
+                    :disabled="!visualChordClipboard || visualSelectedLines.size === 0"
+                    @click="pasteChordPattern()">📥 Pegar acordes</button>
+
+            <span class="sep"></span>
+            <button class="btn-mini" :disabled="getChorusBlocks().length === 0"
+                    @click="insertChorusHere()">🔁 Insertar estribillo</button>
+
+            <span class="sel-clear" x-show="visualSelectedLines.size > 0"
+                  @click="clearLineSelection()">Limpiar selección</span>
+
+            <button class="btn-mini help-mini" @click="showHelp = true" title="Ayuda">❓</button>
           </div>
+
+          <div class="visual-add-hint" x-show="visualAddMode" x-cloak>
+            🟢 Modo añadir activado — pincha sobre cualquier letra para insertar un acorde nuevo.
+          </div>
+
           <div class="visual-doc"
                @click="onVisualClick($event)"
                @keydown.delete.prevent="deleteSelectedChord()"
                @keydown.backspace.prevent="deleteSelectedChord()"
                tabindex="0">
             <template x-for="(ln, idx) in editor.parsed" :key="idx">
-              <div :class="'ed-line ed-' + ln.type" :data-line-idx="idx">
-                <!-- meta / directives shown as compact tags -->
+              <div :class="lineCssClass(ln, idx)" :data-line-idx="idx">
+                <div class="line-gutter"
+                     @click.stop="toggleLineSelection(idx, $event)"
+                     title="Click selecciona · Shift+click rango"
+                     x-text="visualSelectedLines.has(idx) ? '◉' : '○'"></div>
                 <template x-if="ln.type === 'directive' || ln.type === 'comment'">
                   <div class="ed-meta-line" x-text="ln.raw"></div>
                 </template>
                 <template x-if="ln.type === 'soc'">
-                  <div class="ed-marker">▶ Inicio estribillo</div>
+                  <div class="ed-marker chorus-start">▶ Inicio estribillo
+                    <button class="link-mini" @click.stop="removeChorusMarkerAt(idx)">✕</button>
+                  </div>
                 </template>
                 <template x-if="ln.type === 'eoc'">
-                  <div class="ed-marker">◀ Fin estribillo</div>
+                  <div class="ed-marker chorus-end">◀ Fin estribillo
+                    <button class="link-mini" @click.stop="removeChorusMarkerAt(idx)">✕</button>
+                  </div>
                 </template>
                 <template x-if="ln.type === 'blank'">
-                  <div class="ed-blank">·</div>
+                  <div class="ed-blank"></div>
                 </template>
                 <template x-if="ln.type === 'lyric'">
                   <div class="ed-line-row">
                     <div class="ed-chords-layer"></div>
-                    <div class="ed-lyric-row">
+                    <div class="ed-lyric-row"
+                         @dblclick.stop="editLyricLine(idx)">
                       <template x-for="(ch, i) in ln.lyric" :key="i">
-                        <span class="ed-char" :data-idx="i" x-text="ch === ' ' ? ' ' : ch"></span>
+                        <span class="ed-char" :data-idx="i" x-text="ch === ' ' ? ' ' : ch"></span>
                       </template>
                       <span class="ed-char ed-end" :data-idx="ln.lyric.length">⏎</span>
                     </div>

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -225,10 +225,18 @@ table.songs tr.has-warn td { background: #fffbeb; }
 .placeholder { padding: 60px; text-align: center; color: var(--fg-3); }
 
 /* Visual editor */
-.visual-toolbar { display: flex; gap: 12px; align-items: center; padding: 8px 0 12px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-.visual-toolbar .hint { color: var(--fg-3); font-size: 12px; }
-.visual-toolbar .hint kbd { background: var(--bg-3); padding: 1px 5px; border-radius: 3px; font-size: 11px; border: 1px solid var(--border-strong); }
-.visual-toolbar .adding-hint { color: var(--accent); font-weight: 600; margin-left: 8px; }
+.visual-toolbar {
+  display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
+  padding: 6px 8px; background: var(--bg-3); border-radius: 6px;
+  margin-bottom: 8px; position: sticky; top: 0; z-index: 5;
+}
+.visual-toolbar .sep { width: 1px; height: 18px; background: var(--border-strong); margin: 0 4px; }
+.visual-toolbar .sel-info { font-size: 12px; color: var(--accent); font-weight: 600; padding: 0 4px; }
+.visual-toolbar .sel-clear { font-size: 11px; color: var(--fg-3); cursor: pointer; margin-left: auto; padding: 0 6px; }
+.visual-toolbar .sel-clear:hover { color: var(--danger); text-decoration: underline; }
+.visual-toolbar .help-mini { background: transparent; border: none; font-size: 14px; cursor: pointer; margin-left: auto; }
+
+.visual-add-hint { background: rgba(22, 163, 74, 0.12); color: var(--ok); padding: 6px 10px; border-radius: 4px; font-size: 12px; margin-bottom: 6px; }
 
 .visual-doc {
   outline: none; padding: 16px; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px;
@@ -245,7 +253,14 @@ table.songs tr.has-warn td { background: #fffbeb; }
   display: inline-block; margin: 4px 0;
 }
 .ed-line.ed-comment .ed-meta-line { color: var(--todo); }
-.ed-marker { font-size: 11px; color: var(--warn); padding: 6px 0; text-transform: uppercase; letter-spacing: 0.05em; }
+.ed-marker {
+  font-size: 11px; color: var(--warn); padding: 3px 8px; text-transform: uppercase; letter-spacing: 0.05em;
+  background: rgba(202, 138, 4, 0.1); display: inline-flex; align-items: center; gap: 6px;
+  border-radius: 3px; margin: 6px 0 2px 28px;
+}
+.ed-marker.chorus-end { color: var(--warn); }
+.ed-marker .link-mini { background: none; border: none; color: inherit; cursor: pointer; font-size: 11px; opacity: 0.6; }
+.ed-marker .link-mini:hover { opacity: 1; color: var(--danger); }
 
 .ed-line-row { position: relative; margin: 18px 0 2px; min-height: 2em; padding-left: 28px; }
 .ed-chords-layer { position: absolute; top: -1.05em; left: 28px; right: 0; height: 1.1em; pointer-events: none; }

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -1,0 +1,207 @@
+/* Cantoral Admin · estilos vanilla */
+:root {
+  --bg: #fafafa;
+  --bg-2: #fff;
+  --bg-3: #f3f4f6;
+  --fg: #1a1a1a;
+  --fg-2: #555;
+  --fg-3: #888;
+  --border: #e5e7eb;
+  --border-strong: #d1d5db;
+  --accent: #2563eb;
+  --accent-fg: #fff;
+  --ok: #16a34a;
+  --info: #0891b2;
+  --warn: #ca8a04;
+  --todo: #ea580c;
+  --danger: #dc2626;
+  --sidebar-bg: #1f2937;
+  --sidebar-fg: #e5e7eb;
+  --sidebar-fg-dim: #9ca3af;
+  --sidebar-active: #374151;
+}
+.theme-dark {
+  --bg: #111827;
+  --bg-2: #1f2937;
+  --bg-3: #374151;
+  --fg: #f3f4f6;
+  --fg-2: #d1d5db;
+  --fg-3: #9ca3af;
+  --border: #374151;
+  --border-strong: #4b5563;
+  --accent: #3b82f6;
+}
+
+* { box-sizing: border-box; }
+[x-cloak] { display: none !important; }
+html, body { margin: 0; padding: 0; height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+body { display: flex; background: var(--bg); color: var(--fg); }
+
+/* ─────────── SIDEBAR ─────────── */
+.sidebar {
+  width: 260px; min-width: 260px;
+  background: var(--sidebar-bg); color: var(--sidebar-fg);
+  display: flex; flex-direction: column;
+  padding: 16px 0;
+  height: 100vh; overflow-y: auto;
+}
+.brand { display: flex; align-items: center; gap: 10px; padding: 0 18px 16px; border-bottom: 1px solid #374151; }
+.brand-emoji { font-size: 28px; }
+.brand-title { font-weight: 700; font-size: 16px; }
+.brand-sub { color: var(--sidebar-fg-dim); font-size: 12px; }
+
+.sidebar nav { display: flex; flex-direction: column; padding: 14px 8px; gap: 2px; }
+.sidebar nav a {
+  color: var(--sidebar-fg); padding: 8px 12px; border-radius: 6px;
+  text-decoration: none; font-size: 14px;
+}
+.sidebar nav a:hover, .sidebar nav a.active { background: var(--sidebar-active); }
+
+.sidebar-section { padding: 8px 8px; border-top: 1px solid #374151; margin-top: 8px; flex: 1; }
+.sidebar-section-title { font-size: 11px; text-transform: uppercase; color: var(--sidebar-fg-dim); padding: 8px 12px 4px; letter-spacing: 0.05em; }
+.cat-link {
+  display: grid; grid-template-columns: 30px 1fr auto; align-items: center;
+  padding: 6px 12px; border-radius: 6px;
+  color: var(--sidebar-fg); text-decoration: none; font-size: 13px;
+}
+.cat-link:hover, .cat-link.active { background: var(--sidebar-active); }
+.cat-letter { color: var(--sidebar-fg-dim); font-weight: 600; }
+.cat-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cat-count { color: var(--sidebar-fg-dim); font-size: 11px; }
+
+.sidebar-foot { padding: 12px; display: flex; gap: 6px; flex-wrap: wrap; }
+.sidebar-foot button {
+  background: transparent; color: var(--sidebar-fg); border: 1px solid #374151;
+  padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 12px;
+}
+
+/* ─────────── MAIN ─────────── */
+main { flex: 1; padding: 28px 36px; overflow-y: auto; height: 100vh; }
+h1 { margin-top: 0; font-size: 24px; display: flex; align-items: center; gap: 12px; }
+.filter-tag { color: var(--fg-3); font-weight: 400; font-size: 16px; }
+.muted { color: var(--fg-2); }
+.loading { padding: 60px; text-align: center; color: var(--fg-3); }
+.error { padding: 20px; background: #fee; color: #c00; border-radius: 6px; }
+code { background: var(--bg-3); padding: 1px 5px; border-radius: 3px; font-size: 0.9em; }
+
+/* Dashboard */
+.stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 20px 0; }
+.stat { background: var(--bg-2); border: 1px solid var(--border); border-radius: 8px; padding: 20px; }
+.stat-val { font-size: 36px; font-weight: 700; line-height: 1.1; }
+.stat-lbl { color: var(--fg-2); font-size: 13px; margin-top: 4px; }
+.stat.warn { border-left: 4px solid var(--warn); }
+.stat.todo { border-left: 4px solid var(--todo); }
+.stat.info { border-left: 4px solid var(--info); }
+
+.actions-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 24px; }
+.output { margin-top: 20px; background: #000; color: #0f0; padding: 14px; border-radius: 6px; max-height: 400px; overflow: auto; font-family: monospace; font-size: 12px; }
+.output pre { margin: 0; white-space: pre-wrap; }
+
+/* Buttons */
+.btn { background: var(--bg-2); color: var(--fg); border: 1px solid var(--border-strong); padding: 8px 14px; border-radius: 6px; cursor: pointer; font-size: 14px; }
+.btn:hover:not(:disabled) { background: var(--bg-3); }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+.btn.primary:hover:not(:disabled) { background: #1d4ed8; }
+.btn.danger { background: var(--danger); color: white; border-color: var(--danger); }
+.btn-mini { font-size: 12px; padding: 3px 8px; background: var(--bg-3); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; color: var(--fg); margin-right: 4px; }
+.btn-mini.danger { background: transparent; border-color: var(--danger); color: var(--danger); }
+.btn-mini:hover { background: var(--accent); color: white; border-color: var(--accent); }
+
+/* Filter bar */
+.filter-bar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin: 16px 0; padding: 12px; background: var(--bg-2); border-radius: 6px; border: 1px solid var(--border); }
+.filter-bar input[type=search], .filter-bar select { padding: 6px 10px; border: 1px solid var(--border-strong); border-radius: 4px; font-size: 13px; background: var(--bg-2); color: var(--fg); }
+.filter-bar input[type=search] { min-width: 280px; }
+.filter-bar label { display: flex; gap: 4px; align-items: center; font-size: 13px; cursor: pointer; }
+.filter-bar button { padding: 6px 12px; background: var(--bg-3); border: 1px solid var(--border-strong); border-radius: 4px; cursor: pointer; font-size: 13px; color: var(--fg); }
+.filter-bar .count { margin-left: auto; color: var(--fg-3); font-size: 13px; }
+
+/* Songs table */
+table.songs { width: 100%; background: var(--bg-2); border-collapse: collapse; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+table.songs th { text-align: left; background: var(--bg-3); padding: 10px 12px; font-size: 12px; text-transform: uppercase; color: var(--fg-2); font-weight: 600; }
+table.songs td { padding: 8px 12px; border-top: 1px solid var(--border); font-size: 13px; }
+table.songs tr:hover td { background: var(--bg-3); }
+table.songs a { color: var(--accent); text-decoration: none; font-weight: 500; }
+table.songs a:hover { text-decoration: underline; }
+table.songs tr.has-warn td { background: #fffbeb; }
+.theme-dark table.songs tr.has-warn td { background: #422006; }
+
+/* Badges */
+.badge { font-size: 14px; margin-right: 2px; cursor: help; }
+.badge.ok { color: var(--ok); }
+.badge.info { color: var(--info); }
+.badge.todo { color: var(--todo); }
+.warn-cell { font-size: 11px; color: var(--warn); }
+
+/* Import results */
+.import-results { margin-top: 20px; background: var(--bg-2); padding: 16px; border-radius: 6px; border: 1px solid var(--border); }
+.import-results ul { list-style: none; padding: 0; margin: 0; max-height: 300px; overflow: auto; }
+.import-results li { padding: 4px 0; font-size: 13px; display: flex; gap: 8px; align-items: center; }
+.import-results li.ok { color: var(--ok); }
+.import-results li.err { color: var(--danger); }
+.import-results .path { color: var(--fg-3); font-family: monospace; font-size: 11px; }
+.import-results .error-msg { color: var(--danger); }
+
+/* Reorder */
+.reorder-list { list-style: none; padding: 0; margin: 16px 0; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; }
+.reorder-list li {
+  display: grid; grid-template-columns: 30px 50px 90px 1fr 220px; gap: 10px; align-items: center;
+  padding: 8px 12px; border-bottom: 1px solid var(--border); cursor: grab; font-size: 13px;
+}
+.reorder-list li:hover { background: var(--bg-3); }
+.reorder-list .grip { color: var(--fg-3); cursor: grab; }
+.reorder-list .new-num { font-weight: 700; color: var(--accent); }
+.reorder-list .old-num { color: var(--fg-3); font-size: 11px; }
+.reorder-list .filename { color: var(--fg-3); font-family: monospace; font-size: 11px; text-align: right; }
+
+/* Editor overlay */
+.editor-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 100;
+  display: flex; align-items: center; justify-content: center; padding: 24px;
+}
+.editor-modal {
+  background: var(--bg); border-radius: 10px; box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  width: 95vw; max-width: 1200px; height: 90vh; display: flex; flex-direction: column;
+}
+.editor-modal.small { max-width: 800px; height: 80vh; }
+.editor-header { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px; border-bottom: 1px solid var(--border); }
+.editor-header h2 { margin: 0; font-size: 18px; display: flex; align-items: center; gap: 10px; }
+.editor-actions { display: flex; gap: 8px; }
+.editor-tabs { display: flex; gap: 4px; padding: 8px 20px 0; border-bottom: 1px solid var(--border); background: var(--bg-2); }
+.editor-tabs button {
+  background: transparent; border: none; padding: 10px 16px; cursor: pointer; font-size: 13px;
+  color: var(--fg-2); border-bottom: 2px solid transparent;
+}
+.editor-tabs button.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+.editor-tabs .dirty { margin-left: auto; padding: 10px; color: var(--warn); font-size: 12px; }
+
+.editor-body { flex: 1; display: grid; grid-template-columns: 280px 1fr; min-height: 0; }
+.editor-body.single { grid-template-columns: 1fr; }
+.editor-meta { padding: 16px; border-right: 1px solid var(--border); background: var(--bg-2); overflow-y: auto; }
+.editor-meta h4 { margin: 0 0 12px; font-size: 14px; }
+.editor-meta label { display: block; font-size: 11px; color: var(--fg-2); text-transform: uppercase; margin: 12px 0 4px; }
+.editor-meta input { width: 100%; padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: 4px; font-size: 13px; background: var(--bg); color: var(--fg); }
+.editor-meta .path-info { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
+.editor-meta .path-info small { color: var(--fg-3); font-family: monospace; word-break: break-all; }
+
+.editor-pane { flex: 1; padding: 16px; overflow: auto; }
+.editor-pane.raw textarea {
+  width: 100%; height: 100%; min-height: 400px; resize: none;
+  font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 13px; line-height: 1.6;
+  border: 1px solid var(--border); border-radius: 4px; padding: 12px;
+  background: var(--bg-2); color: var(--fg);
+}
+.editor-pane pre { white-space: pre-wrap; font-family: monospace; font-size: 13px; }
+.placeholder { padding: 60px; text-align: center; color: var(--fg-3); }
+
+/* Preview render */
+.preview-render { font-family: Georgia, serif; line-height: 1.8; }
+.preview-render .pv-title { font-size: 22px; margin: 0 0 12px; }
+.preview-render .pv-meta { font-size: 12px; color: var(--fg-3); }
+.preview-render .pv-chorus { background: #fef3c7; padding: 8px 12px; border-left: 3px solid var(--warn); margin: 10px 0; }
+.theme-dark .preview-render .pv-chorus { background: #422006; }
+.preview-render .pv-blank { height: 1em; }
+.preview-render .pv-line { white-space: nowrap; margin: 22px 0 0; min-height: 2.4em; }
+.preview-render .pv-seg { display: inline-block; vertical-align: top; position: relative; }
+.preview-render .pv-chords { display: block; color: var(--accent); font-weight: 700; font-family: 'SF Mono', monospace; font-size: 0.85em; height: 1.2em; }
+.preview-render .pv-lyr { display: block; white-space: pre; font-size: 1em; }

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -194,6 +194,57 @@ table.songs tr.has-warn td { background: #fffbeb; }
 .editor-pane pre { white-space: pre-wrap; font-family: monospace; font-size: 13px; }
 .placeholder { padding: 60px; text-align: center; color: var(--fg-3); }
 
+/* Visual editor */
+.visual-toolbar { display: flex; gap: 12px; align-items: center; padding: 8px 0 12px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
+.visual-toolbar .hint { color: var(--fg-3); font-size: 12px; }
+.visual-toolbar .hint kbd { background: var(--bg-3); padding: 1px 5px; border-radius: 3px; font-size: 11px; border: 1px solid var(--border-strong); }
+.visual-toolbar .adding-hint { color: var(--accent); font-weight: 600; margin-left: 8px; }
+
+.visual-doc {
+  outline: none; padding: 16px; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px;
+  font-family: "Calibri", "Carlito", "Segoe UI", sans-serif;
+  user-select: text;
+}
+.visual-doc:focus { box-shadow: 0 0 0 2px var(--accent); }
+.ed-line { margin: 0; }
+.ed-line.ed-blank { height: 14px; }
+.ed-line.ed-directive .ed-meta-line,
+.ed-line.ed-comment .ed-meta-line {
+  font-family: monospace; font-size: 12px; color: var(--fg-3);
+  padding: 2px 6px; background: var(--bg-3); border-radius: 3px;
+  display: inline-block; margin: 4px 0;
+}
+.ed-line.ed-comment .ed-meta-line { color: var(--todo); }
+.ed-marker { font-size: 11px; color: var(--warn); padding: 6px 0; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.ed-line-row { position: relative; margin: 28px 0 6px; min-height: 2.6em; }
+.ed-chords-layer { position: absolute; top: -1.5em; left: 0; right: 0; height: 1.4em; pointer-events: none; }
+.ed-lyric-row { white-space: pre; font-size: 16px; line-height: 1.5; }
+.ed-char {
+  display: inline-block; min-width: 0.25em; line-height: 1.4;
+  border-bottom: 1px dotted transparent;
+}
+.ed-char.ed-end { color: var(--fg-3); margin-left: 4px; font-size: 0.7em; }
+
+/* When in add mode, highlight chars on hover */
+.visual-doc.add-mode-on .ed-char:hover,
+body.adding .ed-char:hover { background: rgba(37, 99, 235, 0.15); cursor: pointer; }
+
+.ed-chord {
+  position: absolute; top: 0;
+  background: rgba(37, 99, 235, 0.92); color: white;
+  padding: 1px 5px; border-radius: 3px;
+  font-family: 'SF Mono', Menlo, monospace; font-size: 12px; font-weight: 700;
+  cursor: grab; pointer-events: auto;
+  transform: translateX(-50%); /* center on the char */
+  user-select: none;
+  transition: background 0.1s;
+  white-space: nowrap;
+}
+.ed-chord:hover { background: var(--accent); box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
+.ed-chord.selected { background: var(--todo); box-shadow: 0 0 0 2px rgba(234, 88, 12, 0.4); }
+.ed-chord.dragging { cursor: grabbing; opacity: 0.85; transform: translateX(-50%) scale(1.1); z-index: 10; }
+
 /* Preview render */
 .preview-render { font-family: Georgia, serif; line-height: 1.8; }
 .preview-render .pv-title { font-size: 22px; margin: 0 0 12px; }

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -76,8 +76,38 @@ body { display: flex; background: var(--bg); color: var(--fg); }
 }
 
 /* ─────────── MAIN ─────────── */
-main { flex: 1; padding: 28px 36px; overflow-y: auto; height: 100vh; }
+main { flex: 1; padding: 16px 36px 28px; overflow-y: auto; height: 100vh; position: relative; }
 h1 { margin-top: 0; font-size: 24px; display: flex; align-items: center; gap: 12px; }
+.topbar { display: flex; justify-content: flex-end; align-items: center; gap: 12px; margin-bottom: 8px; }
+.save-indicator { padding: 4px 10px; border-radius: 12px; font-size: 12px; background: var(--bg-3); color: var(--fg-3); transition: all 0.2s; min-width: 120px; text-align: center; }
+.save-indicator.saved { background: rgba(22, 163, 74, 0.12); color: var(--ok); }
+.save-indicator.dirty { background: rgba(234, 88, 12, 0.12); color: var(--todo); }
+.save-indicator.saving { background: rgba(8, 145, 178, 0.15); color: var(--info); }
+.save-indicator.error { background: rgba(220, 38, 38, 0.15); color: var(--danger); }
+.topbar-help { background: var(--bg-2); border: 1px solid var(--border-strong); width: 28px; height: 28px; border-radius: 14px; cursor: pointer; font-size: 14px; color: var(--fg); }
+.topbar-help:hover { background: var(--accent); color: white; }
+
+.commit-reminder { margin-top: 26px; padding: 16px 20px; background: var(--bg-2); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 6px; }
+.commit-reminder h3 { margin: 0 0 8px; font-size: 15px; }
+.commit-reminder p { margin: 6px 0; color: var(--fg-2); font-size: 13px; }
+
+.form-grid { display: grid; grid-template-columns: 140px 1fr; gap: 10px 14px; align-items: start; margin-bottom: 16px; }
+.form-grid label { font-size: 12px; color: var(--fg-2); text-transform: uppercase; padding-top: 6px; }
+.form-grid input, .form-grid select, .form-grid textarea {
+  padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: 4px; font-size: 13px;
+  background: var(--bg-2); color: var(--fg); font-family: inherit;
+}
+.form-grid textarea { min-height: 200px; font-family: monospace; font-size: 12px; }
+.muted.small { font-size: 12px; }
+
+.kbd-help { width: 100%; border-collapse: collapse; }
+.kbd-help th { text-align: left; padding: 6px 12px 6px 0; font-weight: 600; font-size: 13px; vertical-align: top; width: 38%; }
+.kbd-help td { padding: 6px 0; font-size: 13px; color: var(--fg-2); vertical-align: top; }
+.kbd-help kbd { background: var(--bg-3); padding: 1px 6px; border-radius: 3px; font-size: 11px; border: 1px solid var(--border-strong); font-family: inherit; }
+.editor-modal h3 { margin: 16px 0 6px; font-size: 15px; }
+.editor-modal h3:first-child { margin-top: 0; }
+.editor-modal ol, .editor-modal ul { padding-left: 22px; font-size: 13px; color: var(--fg-2); }
+
 .filter-tag { color: var(--fg-3); font-weight: 400; font-size: 16px; }
 .muted { color: var(--fg-2); }
 .loading { padding: 60px; text-align: center; color: var(--fg-3); }
@@ -217,14 +247,30 @@ table.songs tr.has-warn td { background: #fffbeb; }
 .ed-line.ed-comment .ed-meta-line { color: var(--todo); }
 .ed-marker { font-size: 11px; color: var(--warn); padding: 6px 0; text-transform: uppercase; letter-spacing: 0.05em; }
 
-.ed-line-row { position: relative; margin: 28px 0 6px; min-height: 2.6em; }
-.ed-chords-layer { position: absolute; top: -1.5em; left: 0; right: 0; height: 1.4em; pointer-events: none; }
-.ed-lyric-row { white-space: pre; font-size: 16px; line-height: 1.5; }
+.ed-line-row { position: relative; margin: 18px 0 2px; min-height: 2em; padding-left: 28px; }
+.ed-chords-layer { position: absolute; top: -1.05em; left: 28px; right: 0; height: 1.1em; pointer-events: none; }
+.ed-lyric-row { white-space: pre; font-size: 15px; line-height: 1.25; }
 .ed-char {
-  display: inline-block; min-width: 0.25em; line-height: 1.4;
+  display: inline-block; min-width: 0.25em; line-height: 1.15;
   border-bottom: 1px dotted transparent;
 }
 .ed-char.ed-end { color: var(--fg-3); margin-left: 4px; font-size: 0.7em; }
+.ed-line.ed-blank { height: 8px; }
+.ed-line .line-gutter {
+  position: absolute; left: 0; top: 0; width: 24px; height: 100%;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: transparent; font-size: 12px; user-select: none;
+}
+.ed-line:hover .line-gutter { color: var(--fg-3); }
+.ed-line.selected .line-gutter { color: var(--accent); }
+.ed-line.selected .ed-lyric-row { background: rgba(37, 99, 235, 0.08); }
+.theme-dark .ed-line.selected .ed-lyric-row { background: rgba(59, 130, 246, 0.18); }
+.ed-line.ed-soc + .ed-line.ed-lyric .ed-line-row,
+.ed-line.ed-lyric + .ed-line.ed-lyric .ed-line-row {
+  margin-top: 14px;
+}
+.ed-line.ed-lyric.in-chorus .ed-lyric-row { background-image: linear-gradient(to right, rgba(202, 138, 4, 0.06), transparent 30%); }
+.theme-dark .ed-line.ed-lyric.in-chorus .ed-lyric-row { background-image: linear-gradient(to right, rgba(234, 179, 8, 0.12), transparent 30%); }
 
 /* When in add mode, highlight chars on hover */
 .visual-doc.add-mode-on .ed-char:hover,

--- a/scripts/docx2chordpro.py
+++ b/scripts/docx2chordpro.py
@@ -1,0 +1,1079 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""docx2chordpro.py
+
+Migra las canciones del Word "Cantoral Consolación Castellón v2.0.4.docx" a ChordPro.
+
+El script está pensado EXCLUSIVAMENTE para ese .docx. Lee el XML directamente y
+reconstruye la posición de los acordes en píxeles (Calibri, tamaño per-run del
+propio docx, tabuladores en DXA) para emparejarlos con el carácter de la letra
+que está debajo. Soporta tabuladores y espacios indistintamente, y respeta los
+tamaños de fuente excepcionales (canciones que se reducen para caber).
+
+Uso típico (Windows / Mac / Linux):
+
+  python docx2chordpro.py list                      # lista todas las canciones
+  python docx2chordpro.py list --section A          # solo cantos de entrada
+  python docx2chordpro.py list --missing            # solo las que faltan en /songs
+  python docx2chordpro.py show 12                   # imprime la canción 12 ya convertida
+  python docx2chordpro.py extract 12                # guarda en scripts/staging_docx2cho/
+  python docx2chordpro.py extract 12 --write        # guarda directamente en songs/<categoria>/
+  python docx2chordpro.py extract --all             # vuelca todas a staging
+  python docx2chordpro.py compare 12                # diff entre conversion y .cho existente
+  python docx2chordpro.py compare --all             # idem para todas las que ya existen
+
+El id puede ser:
+  - número entero (índice mostrado por 'list')
+  - una porción del título, ej. "dios esta aqui"
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import difflib
+import os
+import re
+import sys
+import unicodedata
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+from xml.etree import ElementTree as ET
+
+try:
+    from PIL import ImageFont
+except ImportError:
+    print("Falta Pillow. Instálalo con:  pip install pillow", file=sys.stderr)
+    sys.exit(1)
+
+
+# ─────────── Rutas y constantes ─────────── #
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_DIR = SCRIPT_DIR.parent
+SONGS_DIR = REPO_DIR / "songs"
+STAGING_DIR = SCRIPT_DIR / "staging_docx2cho"
+FONT_PATH = SCRIPT_DIR / "fuente.ttf"  # Calibri Regular (verificado)
+DOCX_GLOB = "Cantoral*Castell*v2.0.4.docx"  # tolerante a NFC/NFD del nombre
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+W = lambda tag: f"{{{W_NS}}}{tag}"
+
+DEFAULT_TAB_DXA = 720  # twips (1.27 cm = 36 pt)
+PX_PER_PT = 96 / 72  # 96 dpi
+PT_PER_DXA = 1 / 20
+
+# Categorías del docx → carpetas reales del repo (prefijo de letra debe coincidir)
+# El script usa el prefijo "A.", "B.", ... y busca la carpeta correspondiente en /songs.
+
+
+# ─────────── Colores / impresión ─────────── #
+
+USE_COLOR = sys.stdout.isatty() and os.name != "nt" or os.environ.get("FORCE_COLOR") == "1"
+def _c(s: str, code: str) -> str:
+    return f"\033[{code}m{s}\033[0m" if USE_COLOR else s
+def cyan(s): return _c(s, "96")
+def green(s): return _c(s, "92")
+def yellow(s): return _c(s, "93")
+def magenta(s): return _c(s, "95")
+def red(s): return _c(s, "91")
+def dim(s): return _c(s, "2")
+
+
+# ─────────── Acordes ES → EN ─────────── #
+
+SP_ROOTS = {"do": "C", "re": "D", "mi": "E", "fa": "F", "sol": "G", "la": "A", "si": "B"}
+SP_RE = re.compile(r"^(do|re|mi|fa|sol|la|si)([#b]?)(.*)$", re.IGNORECASE)
+EN_CHORD_RE = re.compile(
+    r"^[A-G][#b]?(?:m|maj7|maj9|sus[24]?|dim|aug|add9|m7|6|7|9|11|13)?$"
+)
+_INVIS_RE = re.compile(r"[​-‍﻿⁠ ]")
+
+
+def normalize_token(tok: str) -> str:
+    t = unicodedata.normalize("NFKC", tok)
+    t = _INVIS_RE.sub("", t)
+    t = t.replace("♭", "b").replace("♯", "#").strip()
+    return t
+
+
+def translate_one_chord(tok: str) -> Optional[str]:
+    """Traduce UN acorde ES→EN. Devuelve None si no lo reconoce."""
+    t = normalize_token(tok)
+    if not t:
+        return None
+    # Acorde con bajo: DO/SOL → C/G
+    if "/" in t:
+        left, right = t.split("/", 1)
+        lt = translate_one_chord(left)
+        rt = translate_one_chord(right)
+        if lt and rt:
+            return f"{lt}/{rt}"
+        return None
+    # ES (DO, RE, MI, FA, SOL, LA, SI con sufijos)
+    m = SP_RE.match(t)
+    if m:
+        root, acc, suf = m.groups()
+        cand = f"{SP_ROOTS[root.lower()]}{acc}{suf}"
+        if EN_CHORD_RE.match(cand):
+            return cand
+    # Ya está en EN
+    if EN_CHORD_RE.match(t):
+        return t
+    return None
+
+
+def translate_chord_token(tok: str) -> Optional[List[str]]:
+    """Traduce un token del cantoral que puede contener:
+       - un acorde simple:      "DO"        → ["C"]
+       - múltiples con guion:   "DO-mim-lam" → ["C","Em","Am"]
+       - entre paréntesis:      "(SOL7)"    → ["(G7)"]
+       Devuelve None si no se reconoce ningún acorde."""
+    t = normalize_token(tok)
+    if not t:
+        return None
+    paren = t.startswith("(") and t.endswith(")")
+    if paren:
+        t = t[1:-1]
+    # progresión con guiones
+    if "-" in t:
+        out = []
+        for part in t.split("-"):
+            tr = translate_one_chord(part)
+            if tr is None:
+                return None  # si alguno falla, descartamos el token entero
+            out.append(tr)
+        return [f"({c})" for c in out] if paren else out
+    tr = translate_one_chord(t)
+    if tr is None:
+        return None
+    return [f"({tr})"] if paren else [tr]
+
+
+def is_chord_token(tok: str) -> bool:
+    return translate_chord_token(tok) is not None
+
+
+# ─────────── Métrica de texto ─────────── #
+
+_font_cache: Dict[int, "ImageFont.ImageFont"] = {}
+
+
+def get_font(sz_halfpoints: int) -> "ImageFont.ImageFont":
+    sz_halfpoints = max(sz_halfpoints or 24, 8)
+    # Tamaño en píxeles a 96 dpi
+    px = max(int(round((sz_halfpoints / 2) * PX_PER_PT)), 6)
+    if px not in _font_cache:
+        try:
+            _font_cache[px] = ImageFont.truetype(str(FONT_PATH), px)
+        except Exception:
+            _font_cache[px] = ImageFont.load_default()
+    return _font_cache[px]
+
+
+def text_width_px(text: str, sz_halfpoints: int) -> float:
+    if not text:
+        return 0.0
+    return float(get_font(sz_halfpoints).getlength(text))
+
+
+def dxa_to_px(dxa: float) -> float:
+    return float(dxa) * PT_PER_DXA * PX_PER_PT
+
+
+# ─────────── Lectura del docx ─────────── #
+
+
+def find_docx() -> Path:
+    matches = list(SCRIPT_DIR.glob(DOCX_GLOB))
+    if not matches:
+        print(red(f"No encuentro el .docx ({DOCX_GLOB}) en {SCRIPT_DIR}"), file=sys.stderr)
+        sys.exit(2)
+    return matches[0]
+
+
+def load_paragraphs(docx_path: Path) -> List[ET.Element]:
+    with zipfile.ZipFile(docx_path) as z:
+        xml = z.read("word/document.xml")
+    root = ET.fromstring(xml)
+    body = root.find(W("body"))
+    return list(body.findall(W("p"))) if body is not None else []
+
+
+# ─────────── Estructura del docx ─────────── #
+
+
+def paragraph_style(p: ET.Element) -> Optional[str]:
+    ppr = p.find(W("pPr"))
+    if ppr is None:
+        return None
+    pStyle = ppr.find(W("pStyle"))
+    return pStyle.get(W("val")) if pStyle is not None else None
+
+
+def paragraph_text(p: ET.Element) -> str:
+    return "".join(t.text or "" for t in p.iter(W("t")))
+
+
+def paragraph_default_sz(p: ET.Element) -> int:
+    ppr = p.find(W("pPr"))
+    if ppr is not None:
+        rpr = ppr.find(W("rPr"))
+        if rpr is not None:
+            sz = rpr.find(W("sz"))
+            if sz is not None:
+                try:
+                    return int(sz.get(W("val")))
+                except (TypeError, ValueError):
+                    pass
+    return 24  # 12 pt por defecto
+
+
+def run_sz(r: ET.Element, default: int) -> int:
+    rpr = r.find(W("rPr"))
+    if rpr is not None:
+        sz = rpr.find(W("sz"))
+        if sz is not None:
+            try:
+                return int(sz.get(W("val")))
+            except (TypeError, ValueError):
+                pass
+    return default
+
+
+def run_is_bold(r: ET.Element) -> bool:
+    rpr = r.find(W("rPr"))
+    if rpr is None:
+        return False
+    b = rpr.find(W("b"))
+    if b is None:
+        return False
+    val = b.get(W("val"))
+    return val is None or val not in ("0", "false")
+
+
+def paragraph_indent_dxa(p: ET.Element) -> float:
+    ppr = p.find(W("pPr"))
+    if ppr is None:
+        return 0.0
+    ind = ppr.find(W("ind"))
+    if ind is None:
+        return 0.0
+    left = float(ind.get(W("left")) or 0)
+    first = float(ind.get(W("firstLine")) or 0)
+    hanging = float(ind.get(W("hanging")) or 0)
+    return left + first - hanging
+
+
+def paragraph_tab_stops_dxa(p: ET.Element) -> List[float]:
+    ppr = p.find(W("pPr"))
+    if ppr is None:
+        return []
+    tabs = ppr.find(W("tabs"))
+    if tabs is None:
+        return []
+    stops: List[float] = []
+    for tab in tabs.findall(W("tab")):
+        if tab.get(W("val")) == "clear":
+            continue
+        pos = tab.get(W("pos"))
+        if pos:
+            try:
+                stops.append(float(pos))
+            except ValueError:
+                pass
+    return sorted(stops)
+
+
+def next_tab_stop_px(x_px: float, custom_stops_px: Sequence[float],
+                     default_dxa: int = DEFAULT_TAB_DXA) -> float:
+    """Devuelve la siguiente posición de tabulador estrictamente mayor que x_px."""
+    for s in custom_stops_px:
+        if s > x_px + 0.01:
+            return s
+    base_px = custom_stops_px[-1] if custom_stops_px else 0.0
+    if x_px < base_px:
+        x_px = base_px
+    delta = x_px - base_px
+    step_px = dxa_to_px(default_dxa)
+    n = int(delta // step_px) + 1
+    return base_px + n * step_px
+
+
+# ─────────── Extracción de líneas lógicas ─────────── #
+# Cada párrafo puede contener varios <w:br/> que separan "líneas visuales".
+
+Atom = Tuple[str, Optional[str], int, bool]  # (kind, value, sz, bold). kind in {'tab','text'}
+
+
+def paragraph_logical_lines(p: ET.Element) -> List[List[Atom]]:
+    """Devuelve lista de líneas lógicas. Cada línea es lista de Atoms en orden."""
+    default_sz = paragraph_default_sz(p)
+    lines: List[List[Atom]] = [[]]
+    for r in p.findall(W("r")):
+        sz = run_sz(r, default_sz)
+        bold = run_is_bold(r)
+        for child in r:
+            tag = child.tag.split("}")[-1]
+            if tag == "tab":
+                lines[-1].append(("tab", None, sz, bold))
+            elif tag == "t":
+                if child.text:
+                    lines[-1].append(("text", child.text, sz, bold))
+            elif tag == "br":
+                lines.append([])
+    return lines
+
+
+# ─────────── Parsing de líneas ─────────── #
+
+
+def parse_chord_line(atoms: List[Atom], start_x_dxa: float,
+                     tab_stops_dxa: Sequence[float]) -> List[Tuple[float, str]]:
+    """Devuelve lista (x_px, token_acorde_tal_cual_aparece_en_docx)."""
+    cur_x = dxa_to_px(start_x_dxa)
+    tab_stops_px = [dxa_to_px(s) for s in tab_stops_dxa]
+    positions: List[Tuple[float, str]] = []
+    for kind, value, sz, _bold in atoms:
+        if kind == "tab":
+            cur_x = next_tab_stop_px(cur_x, tab_stops_px)
+        elif kind == "text":
+            text = value or ""
+            # Encontrar tokens (no-espacios) con su offset px dentro del segmento
+            i = 0
+            while i < len(text):
+                if not text[i].isspace():
+                    j = i
+                    while j < len(text) and not text[j].isspace():
+                        j += 1
+                    tok = text[i:j]
+                    tok_x = cur_x + text_width_px(text[:i], sz)
+                    positions.append((tok_x, tok))
+                    i = j
+                else:
+                    i += 1
+            cur_x += text_width_px(text, sz)
+    return positions
+
+
+def parse_lyric_line(atoms: List[Atom], start_x_dxa: float,
+                     tab_stops_dxa: Sequence[float]) -> Tuple[str, List[float]]:
+    """Devuelve (texto_visible, posiciones_px_por_caracter).
+    `posiciones[i]` es la x del carácter i. Hay len(texto)+1 entradas (la última = x final)."""
+    cur_x = dxa_to_px(start_x_dxa)
+    tab_stops_px = [dxa_to_px(s) for s in tab_stops_dxa]
+    chars: List[str] = []
+    positions: List[float] = [cur_x]
+    for kind, value, sz, _bold in atoms:
+        if kind == "tab":
+            cur_x = next_tab_stop_px(cur_x, tab_stops_px)
+            # Representamos el tab como un espacio en la letra final
+            chars.append(" ")
+            positions.append(cur_x)
+        elif kind == "text":
+            text = value or ""
+            for ch in text:
+                cur_x += text_width_px(ch, sz)
+                chars.append(ch)
+                positions.append(cur_x)
+    return "".join(chars), positions
+
+
+def line_atoms_text(atoms: List[Atom]) -> str:
+    """Texto de la línea con tabuladores expandidos a un espacio (para clasificar)."""
+    out = []
+    for kind, value, _sz, _bold in atoms:
+        if kind == "tab":
+            out.append(" ")
+        elif kind == "text":
+            out.append(value or "")
+    return "".join(out)
+
+
+def line_is_bold(atoms: List[Atom]) -> bool:
+    """True si la mayoría del texto no-espacio de la línea es negrita."""
+    bold_chars = 0
+    total_chars = 0
+    for kind, value, _sz, bold in atoms:
+        if kind == "text" and value:
+            for ch in value:
+                if not ch.isspace():
+                    total_chars += 1
+                    if bold:
+                        bold_chars += 1
+    return total_chars > 0 and bold_chars / total_chars >= 0.6
+
+
+def line_is_uppercase(text: str) -> bool:
+    """True si la línea está mayoritariamente en MAYÚSCULAS (>=70% de letras)."""
+    letters = [ch for ch in text if ch.isalpha()]
+    if len(letters) < 3:
+        return False
+    upper = sum(1 for ch in letters if ch.isupper())
+    return upper / len(letters) >= 0.70
+
+
+def classify_line(atoms: List[Atom]) -> str:
+    """Devuelve 'chord' | 'lyric' | 'empty'."""
+    text = line_atoms_text(atoms).strip()
+    if not text:
+        return "empty"
+    tokens = re.findall(r"\S+", text)
+    if not tokens:
+        return "empty"
+    recognized = sum(1 for tok in tokens if is_chord_token(tok))
+    return "chord" if recognized / len(tokens) >= 0.6 else "lyric"
+
+
+# ─────────── Inyección de acordes ─────────── #
+
+
+def closest_index(positions: List[float], x: float) -> int:
+    pos = bisect.bisect_left(positions, x)
+    if pos == 0:
+        return 0
+    if pos >= len(positions):
+        return len(positions) - 1
+    if abs(positions[pos] - x) < abs(positions[pos - 1] - x):
+        return pos
+    return pos - 1
+
+
+def word_start_indices(text: str) -> List[int]:
+    """Devuelve los índices donde empieza cada palabra (no-espacio precedido de espacio o BOL)."""
+    starts: List[int] = []
+    prev_space = True
+    for i, ch in enumerate(text):
+        if not ch.isspace() and prev_space:
+            starts.append(i)
+        prev_space = ch.isspace()
+    return starts
+
+
+def snap_to_word_start(precise_idx: int, lyric_text: str,
+                       char_positions: List[float], chord_x: float) -> int:
+    """Snap el índice al inicio de palabra más cercano en PÍXELES.
+    Si no hay palabras (línea solo de espacios), devuelve precise_idx."""
+    starts = word_start_indices(lyric_text)
+    if not starts:
+        return precise_idx
+    # candidate: cada inicio de palabra + final de línea (para acordes que caen al final)
+    candidates = list(starts) + [len(lyric_text)]
+    best = min(candidates, key=lambda s: abs(char_positions[s] - chord_x))
+    return best
+
+
+def inject_chords(lyric_text: str, char_positions: List[float],
+                  chord_positions: List[Tuple[float, str]]) -> str:
+    """Inserta los acordes traducidos en la letra. Conserva el texto tal cual.
+    Política:
+      - Snap al inicio de palabra más cercano en píxeles.
+      - Si dos acordes (de tokens diferentes) caen en la misma palabra, se hace
+        un "spread": el segundo acorde busca el siguiente inicio de palabra libre.
+      - Los acordes derivados de un único token con guiones (ej. "DO-mim-lam")
+        se mantienen apilados en la misma posición, que es lo esperado.
+    """
+    if not chord_positions:
+        return lyric_text
+    if not lyric_text.strip():
+        chunks = []
+        for _, tok in chord_positions:
+            chords = translate_chord_token(tok) or [tok]
+            chunks.append("".join(f"[{c}]" for c in chords))
+        return " ".join(chunks)
+
+    word_starts = word_start_indices(lyric_text)
+    candidates = sorted(set(word_starts + [0, len(lyric_text)]),
+                        key=lambda s: char_positions[s])
+
+    insertions: Dict[int, List[str]] = {}
+    claimed: set = set()
+    for x, tok in sorted(chord_positions, key=lambda p: p[0]):
+        chords = translate_chord_token(tok) or [tok]
+        unclaimed = [c for c in candidates if c not in claimed]
+        if unclaimed:
+            idx = min(unclaimed, key=lambda c: abs(char_positions[c] - x))
+        else:
+            idx = min(candidates, key=lambda c: abs(char_positions[c] - x))
+        claimed.add(idx)
+        insertions.setdefault(idx, []).extend(f"[{c}]" for c in chords)
+
+    out: List[str] = []
+    for i, ch in enumerate(lyric_text):
+        if i in insertions:
+            out.extend(insertions[i])
+        out.append(ch)
+    if len(lyric_text) in insertions:
+        out.extend(insertions[len(lyric_text)])
+    return "".join(out)
+
+
+# ─────────── Procesado de una canción completa ─────────── #
+
+
+def split_into_songs(paras: List[ET.Element]) -> List[dict]:
+    """Devuelve [{section, title_raw, title_para, paragraphs}] en orden del docx.
+
+    `title_para` es el propio Heading2 (puede contener líneas adicionales separadas
+    por <w:br/> que forman parte del cuerpo: caso de canciones que pegaron todo
+    junto en un único párrafo Heading2)."""
+    songs: List[dict] = []
+    current_section: Optional[str] = None
+    current_title_raw: Optional[str] = None
+    current_title_para: Optional[ET.Element] = None
+    current_paras: List[ET.Element] = []
+    for p in paras:
+        style = paragraph_style(p)
+        text = paragraph_text(p).strip()
+        if style == "Heading1":
+            if current_title_raw is not None:
+                songs.append({
+                    "section": current_section,
+                    "title_raw": current_title_raw,
+                    "title_para": current_title_para,
+                    "paragraphs": current_paras,
+                })
+                current_title_raw = None
+                current_title_para = None
+                current_paras = []
+            if text:
+                current_section = text
+        elif style == "Heading2":
+            if current_title_raw is not None:
+                songs.append({
+                    "section": current_section,
+                    "title_raw": current_title_raw,
+                    "title_para": current_title_para,
+                    "paragraphs": current_paras,
+                })
+            # El título: primera línea lógica del párrafo
+            first_line_atoms = paragraph_logical_lines(p)[0]
+            current_title_raw = line_atoms_text(first_line_atoms).strip()
+            current_title_para = p
+            current_paras = []
+        else:
+            if current_title_raw is not None:
+                current_paras.append(p)
+    if current_title_raw is not None:
+        songs.append({
+            "section": current_section,
+            "title_raw": current_title_raw,
+            "title_para": current_title_para,
+            "paragraphs": current_paras,
+        })
+    # Descartar canciones con título vacío (separadores)
+    return [s for s in songs if s["title_raw"]]
+
+
+CAPO_SUFFIX_RE = re.compile(r"\s+C\s*/\s*(\d+)\s*$", re.IGNORECASE)
+
+
+def parse_title(raw: str) -> Tuple[str, Optional[int]]:
+    raw = unicodedata.normalize("NFC", raw).strip()
+    capo = None
+    m = CAPO_SUFFIX_RE.search(raw)
+    if m:
+        try:
+            capo = int(m.group(1))
+        except ValueError:
+            capo = None
+        raw = raw[: m.start()].strip()
+    return raw, capo
+
+
+# Palabras que conservan minúsculas en títulos en español
+TITLE_LOWER = {"a", "ante", "bajo", "con", "de", "del", "desde", "en", "entre",
+               "hacia", "hasta", "para", "por", "según", "segun", "sin", "sobre",
+               "tras", "y", "e", "o", "u", "la", "el", "los", "las", "lo",
+               "un", "una", "al", "ni", "si", "que"}
+
+
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÿñÑ]+")
+
+
+def pretty_title_case(s: str) -> str:
+    """Capitaliza estilo español: primera y resto Capitalizadas excepto preposiciones.
+    Tolera puntuación como '(autor)' o comas."""
+    s = unicodedata.normalize("NFC", s).strip()
+    if not s:
+        return s
+    s = s.lower()
+    word_count = [0]
+
+    def cap(m: re.Match) -> str:
+        w = m.group(0)
+        word_count[0] += 1
+        if word_count[0] > 1 and w in TITLE_LOWER:
+            return w
+        return w[:1].upper() + w[1:]
+
+    return _WORD_RE.sub(cap, s)
+
+
+def slugify(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    s = re.sub(r"_+", "_", s).strip("_")
+    return s or "cancion"
+
+
+def section_letter(section_raw: Optional[str]) -> Optional[str]:
+    if not section_raw:
+        return None
+    m = re.match(r"\s*([A-Z](?:\+\d+)?)\.\s*", section_raw)
+    if not m:
+        return None
+    return m.group(1)
+
+
+def resolve_target_folder(section_raw: Optional[str]) -> Optional[Path]:
+    letter = section_letter(section_raw)
+    if not letter:
+        return None
+    for p in SONGS_DIR.iterdir():
+        if not p.is_dir():
+            continue
+        m = re.match(r"\s*([A-Z](?:\+\d+)?)\.", p.name)
+        if m and m.group(1) == letter:
+            return p
+    return None
+
+
+def next_song_number(folder: Path) -> int:
+    maxn = 0
+    if not folder.exists():
+        return 1
+    for f in folder.iterdir():
+        m = re.match(r"(\d+)\.", f.name)
+        if m:
+            try:
+                maxn = max(maxn, int(m.group(1)))
+            except ValueError:
+                pass
+    return maxn + 1
+
+
+# ─────────── Conversión de una canción ─────────── #
+
+
+def convert_song(song: dict) -> dict:
+    """Devuelve {title, capo, key, section, body, slug, warnings, n_chord_lines}."""
+    title_clean, capo = parse_title(song["title_raw"])
+    section = song["section"]
+    warnings: List[str] = []
+    first_chord_en: Optional[str] = None
+
+    # 1. Aplanar todos los párrafos en una lista de "logical lines" con metadata.
+    #    Si el Heading2 contiene más de una línea lógica, las extras forman parte del cuerpo.
+    lines: List[dict] = []  # {kind, atoms, start_x, tab_stops, bold, text}
+
+    def add_lines_from(p: ET.Element, skip_first: bool = False):
+        start_x = paragraph_indent_dxa(p)
+        tab_stops = paragraph_tab_stops_dxa(p)
+        all_logical = paragraph_logical_lines(p)
+        for k, atoms in enumerate(all_logical):
+            if skip_first and k == 0:
+                continue
+            text = line_atoms_text(atoms)
+            lines.append({
+                "kind": classify_line(atoms),
+                "atoms": atoms,
+                "start_x": start_x,
+                "tab_stops": tab_stops,
+                "bold": line_is_bold(atoms),
+                "text": text,
+            })
+
+    if song.get("title_para") is not None:
+        add_lines_from(song["title_para"], skip_first=True)
+    for p in song["paragraphs"]:
+        add_lines_from(p)
+
+    # 2. Emparejar líneas de acordes con su letra y emitir.
+    out_lines: List[str] = []
+    in_chorus = False
+    pending_chord: Optional[dict] = None
+    last_was_blank = True
+
+    def emit(line: str):
+        nonlocal last_was_blank
+        if line == "" and last_was_blank:
+            return  # evita encadenar líneas vacías
+        out_lines.append(line)
+        last_was_blank = (line == "")
+
+    def open_chorus():
+        nonlocal in_chorus
+        if not in_chorus:
+            if not last_was_blank:
+                emit("")
+            emit("{soc}")
+            in_chorus = True
+
+    def close_chorus():
+        nonlocal in_chorus, last_was_blank
+        if in_chorus:
+            while out_lines and out_lines[-1] == "":
+                out_lines.pop()
+            last_was_blank = False
+            emit("{eoc}")
+            emit("")
+            in_chorus = False
+
+    n_chord_lines = 0
+    for ln in lines:
+        if ln["kind"] == "empty":
+            if pending_chord is not None:
+                # acordes huérfanos sin letra debajo
+                chord_pos = parse_chord_line(pending_chord["atoms"],
+                                             pending_chord["start_x"],
+                                             pending_chord["tab_stops"])
+                if chord_pos and first_chord_en is None:
+                    tr = translate_chord_token(chord_pos[0][1])
+                    if tr:
+                        first_chord_en = tr[0]
+                emit(inject_chords("", [], chord_pos))
+                pending_chord = None
+                n_chord_lines += 1
+            if not last_was_blank:
+                emit("")
+            continue
+
+        if ln["kind"] == "chord":
+            if pending_chord is not None:
+                # 2 líneas de acordes seguidas → emitir la anterior sola
+                chord_pos = parse_chord_line(pending_chord["atoms"],
+                                             pending_chord["start_x"],
+                                             pending_chord["tab_stops"])
+                if chord_pos and first_chord_en is None:
+                    tr = translate_chord_token(chord_pos[0][1])
+                    if tr:
+                        first_chord_en = tr[0]
+                emit(inject_chords("", [], chord_pos))
+                n_chord_lines += 1
+            pending_chord = ln
+            continue
+
+        # ln["kind"] == "lyric"
+        chord_pos: List[Tuple[float, str]] = []
+        if pending_chord is not None:
+            # IMPORTANTE: usamos el indentado de la LETRA (no del de los acordes), porque
+            # el cantoral a veces aplica un indent extra al primer párrafo de acordes
+            # que rompe la alineación. Los tab stops del párrafo de acordes sí se respetan.
+            chord_pos = parse_chord_line(pending_chord["atoms"],
+                                         ln["start_x"],
+                                         pending_chord["tab_stops"])
+            n_chord_lines += 1
+            if chord_pos and first_chord_en is None:
+                tr = translate_chord_token(chord_pos[0][1])
+                if tr:
+                    first_chord_en = tr[0]
+        lyric_text, char_positions = parse_lyric_line(ln["atoms"], ln["start_x"], ln["tab_stops"])
+        line_out = inject_chords(lyric_text, char_positions, chord_pos).rstrip()
+
+        # Detección de estribillo por mayúsculas (más fiable que negrita en este cantoral).
+        is_chorus_line = line_is_uppercase(lyric_text)
+        if is_chorus_line and not in_chorus:
+            open_chorus()
+        elif not is_chorus_line and in_chorus:
+            close_chorus()
+
+        emit(line_out)
+        pending_chord = None
+
+    if pending_chord is not None:
+        chord_pos = parse_chord_line(pending_chord["atoms"],
+                                     pending_chord["start_x"],
+                                     pending_chord["tab_stops"])
+        emit(inject_chords("", [], chord_pos))
+    close_chorus()
+
+    # 3. Limpiar líneas en blanco múltiples al final
+    while out_lines and out_lines[-1] == "":
+        out_lines.pop()
+
+    if n_chord_lines == 0:
+        warnings.append("No se detectó ninguna línea de acordes")
+
+    pretty = pretty_title_case(title_clean)
+    return {
+        "title": pretty,
+        "title_raw": title_clean,
+        "capo": capo,
+        "key": first_chord_en,
+        "section": section,
+        "section_letter": section_letter(section),
+        "slug": slugify(pretty),
+        "body": "\n".join(out_lines),
+        "warnings": warnings,
+        "n_chord_lines": n_chord_lines,
+    }
+
+
+def render_cho(song: dict) -> str:
+    header = [f"{{title: {song['title']}}}"]
+    if song.get("key"):
+        header.append(f"{{key: {song['key']}}}")
+    if song.get("capo"):
+        header.append(f"{{capo: {song['capo']}}}")
+    return "\n".join(header) + "\n\n" + song["body"] + "\n"
+
+
+# ─────────── Catálogo y matching contra .cho existentes ─────────── #
+
+
+TITLE_KEY_RE = re.compile(r"\{\s*title\s*:\s*(.*?)\s*\}", re.IGNORECASE)
+
+
+def normalize_title_for_match(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    return s.strip()
+
+
+def index_existing_cho() -> Dict[str, Path]:
+    """{title_normalizado: path} de todos los .cho existentes en /songs."""
+    idx: Dict[str, Path] = {}
+    if not SONGS_DIR.exists():
+        return idx
+    for cho in SONGS_DIR.rglob("*.cho"):
+        try:
+            head = cho.read_text(encoding="utf-8", errors="replace")[:500]
+        except Exception:
+            continue
+        m = TITLE_KEY_RE.search(head)
+        if not m:
+            continue
+        title = m.group(1).strip()
+        idx[normalize_title_for_match(title)] = cho
+    return idx
+
+
+def find_existing_cho(song: dict, existing_idx: Dict[str, Path]) -> Optional[Path]:
+    key = normalize_title_for_match(song["title"])
+    if key in existing_idx:
+        return existing_idx[key]
+    # Match difuso por substring
+    for k, p in existing_idx.items():
+        if key and (key in k or k in key):
+            return p
+    return None
+
+
+# ─────────── Selección de canción por id ─────────── #
+
+
+def select_song(songs: List[dict], spec: str) -> Tuple[int, dict]:
+    if spec.isdigit():
+        i = int(spec)
+        if not (0 <= i < len(songs)):
+            print(red(f"Índice {i} fuera de rango (0..{len(songs)-1})"), file=sys.stderr)
+            sys.exit(2)
+        return i, songs[i]
+    norm = normalize_title_for_match(spec)
+    candidates = [(i, s) for i, s in enumerate(songs)
+                  if norm in normalize_title_for_match(s["title_raw"])]
+    if not candidates:
+        print(red(f"Sin coincidencias para '{spec}'"), file=sys.stderr)
+        sys.exit(2)
+    if len(candidates) > 1:
+        print(yellow(f"Varias coincidencias para '{spec}':"))
+        for i, s in candidates[:20]:
+            print(f"  {i:3d}  {s['title_raw']}")
+        sys.exit(2)
+    return candidates[0]
+
+
+# ─────────── Comandos CLI ─────────── #
+
+
+def cmd_list(args, songs: List[dict]):
+    existing = index_existing_cho() if args.missing or args.with_status else {}
+    converted_cache: Dict[int, dict] = {}
+    section_filter = args.section.upper() if args.section else None
+    for i, s in enumerate(songs):
+        letter = section_letter(s["section"]) or "?"
+        if section_filter and letter != section_filter:
+            continue
+        conv = None
+        if args.missing or args.with_status:
+            conv = convert_song(s)
+            converted_cache[i] = conv
+            existing_path = find_existing_cho(conv, existing)
+            if args.missing and existing_path is not None:
+                continue
+        title_raw = s["title_raw"]
+        if args.with_status:
+            existing_path = find_existing_cho(conv, existing)
+            mark = green("OK") if existing_path else yellow("..")
+            print(f"  {i:3d}  [{letter}] {mark}  {title_raw}")
+        else:
+            print(f"  {i:3d}  [{letter}]  {title_raw}")
+
+
+def cmd_show(args, songs: List[dict]):
+    i, s = select_song(songs, args.id)
+    conv = convert_song(s)
+    print(magenta(f"# {i}  [{conv['section_letter']}]  {conv['title']}"))
+    if conv["warnings"]:
+        for w in conv["warnings"]:
+            print(yellow(f"# WARN: {w}"))
+    print(render_cho(conv), end="")
+
+
+def _write_song(conv: dict, songs_folder_default: Path, write_real: bool) -> Path:
+    if write_real:
+        folder = resolve_target_folder(conv["section"])
+        if folder is None:
+            print(red(f"No encuentro carpeta destino para sección '{conv['section']}'."),
+                  file=sys.stderr)
+            sys.exit(2)
+        num = next_song_number(folder)
+        fname = f"{num:02d}.{conv['slug']}.cho"
+    else:
+        letter = conv["section_letter"] or "X"
+        section_clean = conv["section"] or "Sin categoría"
+        section_clean = re.sub(r"^\s*[A-Z](?:\+\d+)?\.\s*", "", section_clean)
+        folder = songs_folder_default / f"{letter}. {section_clean}"
+        folder.mkdir(parents=True, exist_ok=True)
+        fname = f"{conv['slug']}.cho"
+    fpath = folder / fname
+    fpath.write_text(render_cho(conv), encoding="utf-8")
+    return fpath
+
+
+def cmd_extract(args, songs: List[dict]):
+    targets: List[Tuple[int, dict]]
+    if args.all:
+        targets = list(enumerate(songs))
+    else:
+        if not args.id:
+            print(red("Indica un id o usa --all"), file=sys.stderr)
+            sys.exit(2)
+        targets = [select_song(songs, args.id)]
+
+    written: List[Path] = []
+    for i, s in targets:
+        conv = convert_song(s)
+        fpath = _write_song(conv, STAGING_DIR, args.write)
+        written.append(fpath)
+        warn = "  " + yellow("|".join(conv["warnings"])) if conv["warnings"] else ""
+        print(f"  {green('✓')} {i:3d}  {fpath.relative_to(REPO_DIR)}{warn}")
+    print()
+    print(green(f"Listo: {len(written)} canción(es) escritas."))
+    if not args.write:
+        print(dim(f"(Modo staging — los .cho están en {STAGING_DIR.relative_to(REPO_DIR)}/)"))
+        print(dim("Para escribir directamente en /songs/<categoría>/ con número auto, añade --write."))
+
+
+def cmd_compare(args, songs: List[dict]):
+    existing = index_existing_cho()
+    targets: List[Tuple[int, dict]]
+    if args.all:
+        targets = list(enumerate(songs))
+    else:
+        targets = [select_song(songs, args.id)]
+
+    n_compared = n_missing = 0
+    for i, s in targets:
+        conv = convert_song(s)
+        existing_path = find_existing_cho(conv, existing)
+        if existing_path is None:
+            if not args.all:
+                print(yellow(f"No existe .cho equivalente para '{conv['title']}'"))
+            n_missing += 1
+            continue
+        n_compared += 1
+        original = existing_path.read_text(encoding="utf-8")
+        generated = render_cho(conv)
+        if args.all:
+            ratio = difflib.SequenceMatcher(None, original, generated).ratio()
+            tag = green("OK") if ratio > 0.85 else (yellow("~~") if ratio > 0.6 else red("XX"))
+            print(f"  {tag} {ratio:5.1%}  {i:3d}  [{conv['section_letter']}] {conv['title']}"
+                  f"  -> {existing_path.relative_to(REPO_DIR)}")
+        else:
+            print(magenta(f"# {i}  {conv['title']}  vs  {existing_path.relative_to(REPO_DIR)}"))
+            diff = difflib.unified_diff(
+                original.splitlines(keepends=False),
+                generated.splitlines(keepends=False),
+                fromfile=f"existing/{existing_path.name}",
+                tofile=f"generated/{existing_path.name}",
+                lineterm="",
+            )
+            shown = False
+            for line in diff:
+                shown = True
+                if line.startswith("+++") or line.startswith("---"):
+                    print(magenta(line))
+                elif line.startswith("@@"):
+                    print(cyan(line))
+                elif line.startswith("+"):
+                    print(green(line))
+                elif line.startswith("-"):
+                    print(red(line))
+                else:
+                    print(line)
+            if not shown:
+                print(green("  (idéntico)"))
+    if args.all:
+        print()
+        print(green(f"Comparadas: {n_compared}.  Sin equivalente .cho: {n_missing}."))
+
+
+# ─────────── Main ─────────── #
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migra canciones del Cantoral Castellón .docx a ChordPro")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="Lista las canciones del docx")
+    p_list.add_argument("--section", help="Filtra por letra de sección (A, B, ...)")
+    p_list.add_argument("--missing", action="store_true", help="Solo las que no existen aún como .cho")
+    p_list.add_argument("--with-status", action="store_true", help="Marca OK/.. según existan ya")
+
+    p_show = sub.add_parser("show", help="Imprime una canción convertida")
+    p_show.add_argument("id", help="Índice numérico o trozo del título")
+
+    p_ext = sub.add_parser("extract", help="Extrae a fichero(s) .cho")
+    g = p_ext.add_mutually_exclusive_group()
+    g.add_argument("id", nargs="?", help="Índice o trozo del título")
+    g.add_argument("--all", action="store_true", help="Todas las canciones")
+    p_ext.add_argument("--write", action="store_true",
+                       help="Escribe directamente en /songs/<categoría>/ con número auto. "
+                            "Por defecto se vuelca a scripts/staging_docx2cho/.")
+
+    p_cmp = sub.add_parser("compare", help="Diff con .cho ya existente")
+    g2 = p_cmp.add_mutually_exclusive_group()
+    g2.add_argument("id", nargs="?", help="Índice o trozo del título")
+    g2.add_argument("--all", action="store_true", help="Compara todas las que tengan equivalente")
+
+    args = parser.parse_args()
+
+    docx = find_docx()
+    paras = load_paragraphs(docx)
+    songs = split_into_songs(paras)
+
+    if args.cmd == "list":
+        cmd_list(args, songs)
+    elif args.cmd == "show":
+        cmd_show(args, songs)
+    elif args.cmd == "extract":
+        cmd_extract(args, songs)
+    elif args.cmd == "compare":
+        cmd_compare(args, songs)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BrokenPipeError:
+        pass
+    except KeyboardInterrupt:
+        print()
+        sys.exit(130)

--- a/scripts/tab2chordpro.py
+++ b/scripts/tab2chordpro.py
@@ -44,6 +44,10 @@ SP_EN: Dict[str,str] = {
 USER_MAP: Dict[str,str] = {}              # Traducciones aprendidas en la sesión
 CHORD_RE = re.compile(r"^[A-G][#b]?(?:m|maj7|sus[24]?|dim|aug|add9|7|9|11|13)?$")
 
+# Marcador para revisar acordes en el admin visual (con espacio entre TO y DO
+# para no confundir con la palabra española "todo").
+TODO_COMMENT_LINE = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
+
 # ───────── Helpers acordes ───────── #
 def clean_chord(tok: str) -> str:
     return tok.replace('(', '').replace(')', '')
@@ -248,13 +252,13 @@ def procesar_archivo_latex(tex_file: Path, base: Path, processed_dir: Path):
     num_in = ask("Número de la canción (blanco = auto)").strip()
     num = (num_in if num_in.isdigit() else str(next_song_number(folder))).zfill(2)
     
-    header = [f"{{title: {titulo}}}"]
+    header = [TODO_COMMENT_LINE, f"{{title: {titulo}}}"]
     if artista: header.append(f"{{artist: {artista}}}")
     if musica_val: header.append(f"{{comment: Música: {musica_val}}}")
     if tono: header.append(f"{{key: {tono}}}")
     if capo: header.append(f"{{capo: {capo}}}")
     if transpose_val: header.append(f"{{transpose: {transpose_val}}}")
-    
+
     fname = f"{num}.{slug}.cho"; fpath = folder / fname
     fpath.write_text("\n".join(header) + "\n\n" + cuerpo, encoding="utf-8")
     ok(f"Archivo creado en ➜ {fpath}")
@@ -327,7 +331,7 @@ def main():
         if not raw: continue
 
         cuerpo=mark_chorus(convert_lines(raw))
-        header=[f"{{title: {titulo}}}"]
+        header=[TODO_COMMENT_LINE, f"{{title: {titulo}}}"]
         if artista: header.append(f"{{artist: {artista}}}")
         if tono: header.append(f"{{key: {tono}}}")
         if capo: header.append(f"{{capo: {capo}}}")


### PR DESCRIPTION
Lee el XML del .docx directamente y reconstruye las posiciones píxel-precisas
de cada acorde (Calibri por-run, tabuladores en DXA, indent del párrafo) para
alinearlos con la letra de debajo. Detecta 225 canciones por estilo Heading2 y
16 secciones por Heading1.

Subcomandos:
  list [--section X] [--missing] [--with-status]
  show <id>           # imprime ChordPro de una canción
  extract <id>|--all  # vuelca a scripts/staging_docx2cho/ (o /songs con --write)
  compare <id>|--all  # diff contra .cho existente

Heurísticas:
  - Línea de acordes vs letra: >=60% tokens reconocidos como acordes ES o EN
  - Estribillo: lyric mayoritariamente MAYÚSCULAS (>=70%)
  - Snap de acordes al inicio de palabra más cercano en píxeles
  - Spread greedy cuando varios acordes caen en la misma palabra
  - Capo: extraído del sufijo "C/X" en el título
  - Key: primer acorde detectado
  - Tono ES→EN: DO→C, lam→Am, FA#m→F#m, DO-mim-lam→[C][Em][Am]

Limitaciones conocidas: 9/225 canciones (<4%) tienen el cuerpo dentro de un
text box de Word; quedan con warning "No se detectó ninguna línea de acordes"
y requieren proceso manual.