### PR TITLE
Mejoras parser docx (snap por sílaba) + editor visual (Carlito, snap indicator, apilado de acordes)

### DIFF
--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -274,29 +274,67 @@ function app() {
         const layer = lineEl.querySelector('.ed-chords-layer');
         if (!layer) return;
         layer.innerHTML = '';
+
         const lyricRow = lineEl.querySelector('.ed-lyric-row');
         const lyricRect = lyricRow.getBoundingClientRect();
         const chars = lyricRow.querySelectorAll('.ed-char');
+
+        // 1) Marcar caracteres que son inicio de sílaba (para hover).
+        const sylSet = new Set(syllableStartsInLine(ln.lyric));
+        const wordSet = new Set(wordStarts(ln.lyric));
+        chars.forEach((c, i) => {
+          c.classList.toggle('ed-syllable-start', sylSet.has(i));
+          c.classList.toggle('ed-word-start', wordSet.has(i));
+        });
+
+        // 2) Agrupar acordes por posición para apilarlos visualmente sin solaparse.
+        const groups = new Map();
         ln.chords.forEach((ch, chordIdx) => {
-          const target = chars[Math.min(ch.pos, chars.length - 1)] || chars[chars.length - 1];
+          const p = Math.max(0, Math.min(ch.pos, ln.lyric.length));
+          if (!groups.has(p)) groups.set(p, []);
+          groups.get(p).push({ ch, chordIdx });
+        });
+
+        groups.forEach((arr, pos) => {
+          const target = chars[Math.min(pos, chars.length - 1)] || chars[chars.length - 1];
           if (!target) return;
-          const t = target.getBoundingClientRect();
-          const left = t.left - lyricRect.left;
-          const el = document.createElement('span');
-          el.className = 'ed-chord';
-          el.dataset.lineIdx = idx;
-          el.dataset.chordIdx = chordIdx;
-          el.style.left = left + 'px';
-          el.textContent = ch.text;
-          if (this.visualSelectedChord &&
-              this.visualSelectedChord.lineIdx === idx &&
-              this.visualSelectedChord.chordIdx === chordIdx) {
-            el.classList.add('selected');
-          }
-          this.attachChordEvents(el);
-          layer.appendChild(el);
+          const baseLeft = target.getBoundingClientRect().left - lyricRect.left;
+          let cumX = baseLeft;
+          arr.forEach(({ ch, chordIdx }) => {
+            const el = document.createElement('span');
+            el.className = 'ed-chord';
+            el.dataset.lineIdx = idx;
+            el.dataset.chordIdx = chordIdx;
+            el.style.left = cumX + 'px';
+            el.textContent = ch.text;
+            if (this.visualSelectedChord &&
+                this.visualSelectedChord.lineIdx === idx &&
+                this.visualSelectedChord.chordIdx === chordIdx) {
+              el.classList.add('selected');
+            }
+            this.attachChordEvents(el);
+            layer.appendChild(el);
+            // Avanzar para el siguiente acorde del mismo grupo (+gap pequeño)
+            const w = el.offsetWidth;
+            cumX += w + 3;
+          });
         });
       });
+    },
+
+    // Resalta la ancla de snap (carácter target) mientras se arrastra un acorde.
+    highlightSnapTarget(lineIdx, charIdx) {
+      // Limpia resaltados previos en toda la canción
+      document.querySelectorAll('.ed-char.snap-hover').forEach(c => c.classList.remove('snap-hover'));
+      if (lineIdx == null || charIdx == null) return;
+      const lineEl = document.querySelector(`.ed-line[data-line-idx="${lineIdx}"]`);
+      if (!lineEl) return;
+      const chars = lineEl.querySelectorAll('.ed-char');
+      const ch = chars[Math.min(charIdx, chars.length - 1)];
+      if (ch) ch.classList.add('snap-hover');
+    },
+    clearSnapHighlight() {
+      document.querySelectorAll('.ed-char.snap-hover').forEach(c => c.classList.remove('snap-hover'));
     },
 
     attachChordEvents(el) {
@@ -321,46 +359,57 @@ function app() {
         const startLeft = parseFloat(el.style.left) || 0;
         dragState = { startX, startLeft, lineIdx, chordIdx, moved: false };
 
+        // Helper para calcular dónde caería el acorde con los modificadores actuales
+        function computeSnapIdx(eventLikeEv) {
+          const lineEl = document.querySelector(`.ed-line[data-line-idx="${dragState.lineIdx}"]`);
+          const lyricRow = lineEl && lineEl.querySelector('.ed-lyric-row');
+          if (!lyricRow) return null;
+          const chars = lyricRow.querySelectorAll('.ed-char');
+          let bestIdx = 0, bestDist = Infinity;
+          const x = eventLikeEv.clientX;
+          chars.forEach((c, i) => {
+            const r = c.getBoundingClientRect();
+            const cx = r.left + r.width / 2;
+            const d = Math.abs(cx - x);
+            if (d < bestDist) { bestDist = d; bestIdx = i; }
+          });
+          const ln = self.editor.parsed[dragState.lineIdx];
+          if (eventLikeEv.altKey) {
+            return bestIdx;  // sin snap
+          } else if (eventLikeEv.shiftKey) {
+            return snapToSyllable(bestIdx, ln.lyric);
+          } else {
+            return snapToWordStart(bestIdx, ln.lyric);
+          }
+        }
+
         function onMove(e) {
           if (!dragState) return;
           const dx = e.clientX - dragState.startX;
           if (Math.abs(dx) > 3) dragState.moved = true;
           el.style.left = (dragState.startLeft + dx) + 'px';
           el.classList.add('dragging');
+          // Indicador en vivo: resaltar la letra a la que se va a anclar
+          if (dragState.moved) {
+            const snapIdx = computeSnapIdx(e);
+            self.highlightSnapTarget(dragState.lineIdx, snapIdx);
+            // Etiqueta del modo activo
+            el.dataset.snapMode = e.altKey ? 'free' : (e.shiftKey ? 'syl' : 'word');
+          }
         }
         function onUp(e) {
           document.removeEventListener('mousemove', onMove);
           document.removeEventListener('mouseup', onUp);
           el.classList.remove('dragging');
+          el.removeAttribute('data-snap-mode');
+          self.clearSnapHighlight();
           if (!dragState || !dragState.moved) {
             dragState = null;
             return;
           }
-          // Find closest char in this line
-          const lineEl = document.querySelector(`.ed-line[data-line-idx="${dragState.lineIdx}"]`);
-          const lyricRow = lineEl && lineEl.querySelector('.ed-lyric-row');
-          if (!lyricRow) { dragState = null; return; }
-          const chars = lyricRow.querySelectorAll('.ed-char');
-          let bestIdx = 0, bestDist = Infinity;
-          const dropX = e.clientX;
-          chars.forEach((c, i) => {
-            const r = c.getBoundingClientRect();
-            const cx = r.left + r.width / 2;
-            const d = Math.abs(cx - dropX);
-            if (d < bestDist) { bestDist = d; bestIdx = i; }
-          });
-          // Snap mode según modificadores:
-          //   sin modif. → snap a inicio de palabra
-          //   Shift     → snap a inicio de sílaba (más fino)
-          //   Alt       → sin snap (pixel-perfect carácter a carácter)
+          const bestIdx = computeSnapIdx(e);
+          if (bestIdx == null) { dragState = null; return; }
           const ln = self.editor.parsed[dragState.lineIdx];
-          if (e.altKey) {
-            // no snap
-          } else if (e.shiftKey) {
-            bestIdx = snapToSyllable(bestIdx, ln.lyric);
-          } else {
-            bestIdx = snapToWordStart(bestIdx, ln.lyric);
-          }
           ln.chords[dragState.chordIdx].pos = bestIdx;
           self.commitParsed();
           self.layoutChords();

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8" />
 <title>Cantoral Admin</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css" />
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 </head>
@@ -397,15 +400,18 @@
         <div class="editor-pane" style="overflow:auto">
           <h3>Editor visual</h3>
           <table class="kbd-help">
-            <tr><th>Arrastrar acorde</th><td>Mueve el acorde. Al soltar hace <em>snap</em> al inicio de palabra más cercano.</td></tr>
-            <tr><th><kbd>Shift</kbd> + soltar</th><td>Snap por <strong>sílaba</strong> (cómo se canta).</td></tr>
-            <tr><th><kbd>Alt</kbd> + soltar</th><td>Sin snap — colocación carácter a carácter (pixel perfect).</td></tr>
+            <tr><th>Arrastrar acorde</th><td>Mueve el acorde. Durante el drag verás en azul la letra donde caerá y una etiqueta del modo (PALABRA/SÍLABA/LIBRE).</td></tr>
+            <tr><th>(sin modificador)</th><td>Snap al inicio de <strong>palabra</strong> más cercano.</td></tr>
+            <tr><th><kbd>Shift</kbd> al soltar</th><td>Snap a inicio de <strong>sílaba</strong> (silabeado español).</td></tr>
+            <tr><th><kbd>Alt</kbd> al soltar</th><td>Sin snap — colocación libre carácter a carácter (pixel-perfect).</td></tr>
+            <tr><th>Hover sobre línea</th><td>Muestra puntos grises (<code>·</code>) en los inicios de sílaba y barras azules en los inicios de palabra, para ver visualmente dónde puedes anclar.</td></tr>
             <tr><th>Doble-click acorde</th><td>Edita texto del acorde (vacío = borrar).</td></tr>
             <tr><th>Click derecho acorde</th><td>Borra con confirmación.</td></tr>
             <tr><th><kbd>Supr</kbd></th><td>Borra el acorde seleccionado.</td></tr>
-            <tr><th>Doble-click en letra</th><td>Edita el texto de esa línea entera.</td></tr>
-            <tr><th>Click en margen izq.</th><td>Selecciona la línea (verde). Útil para marcar estribillos o copiar acordes.</td></tr>
+            <tr><th>Doble-click en letra</th><td>Edita el texto de esa línea entera (los acordes se reubican por palabra).</td></tr>
+            <tr><th>Click en margen izq.</th><td>Selecciona la línea (azul). Útil para marcar estribillos o copiar acordes.</td></tr>
             <tr><th><kbd>Shift</kbd>+click en margen</th><td>Selección de rango.</td></tr>
+            <tr><th><kbd>Ctrl/Cmd</kbd>+<kbd>S</kbd></th><td>Guarda la canción.</td></tr>
           </table>
           <h3>Marcar estribillo</h3>
           <ol>

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -240,7 +240,9 @@ table.songs tr.has-warn td { background: #fffbeb; }
 
 .visual-doc {
   outline: none; padding: 16px; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px;
-  font-family: "Calibri", "Carlito", "Segoe UI", sans-serif;
+  /* Carlito = clon métrico de Calibri (mismas anchuras de caracteres).
+     Por eso los acordes calculados con Calibri caen pixel-fiel en pantalla. */
+  font-family: "Carlito", "Calibri", "Segoe UI", sans-serif;
   user-select: text;
 }
 .visual-doc:focus { box-shadow: 0 0 0 2px var(--accent); }
@@ -297,14 +299,41 @@ body.adding .ed-char:hover { background: rgba(37, 99, 235, 0.15); cursor: pointe
   padding: 1px 5px; border-radius: 3px;
   font-family: 'SF Mono', Menlo, monospace; font-size: 12px; font-weight: 700;
   cursor: grab; pointer-events: auto;
-  transform: translateX(-50%); /* center on the char */
+  /* Sin translate: el acorde se ancla LEFT-aligned al inicio del carácter target.
+     Así varios acordes en la misma posición se apilan a la derecha sin solaparse. */
   user-select: none;
-  transition: background 0.1s;
+  transition: background 0.1s, box-shadow 0.1s;
   white-space: nowrap;
 }
-.ed-chord:hover { background: var(--accent); box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
-.ed-chord.selected { background: var(--todo); box-shadow: 0 0 0 2px rgba(234, 88, 12, 0.4); }
-.ed-chord.dragging { cursor: grabbing; opacity: 0.85; transform: translateX(-50%) scale(1.1); z-index: 10; }
+.ed-chord:hover { background: var(--accent); box-shadow: 0 2px 8px rgba(0,0,0,0.2); z-index: 2; }
+.ed-chord.selected { background: var(--todo); box-shadow: 0 0 0 2px rgba(234, 88, 12, 0.4); z-index: 3; }
+.ed-chord.dragging { cursor: grabbing; opacity: 0.92; transform: scale(1.1); z-index: 10; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
+/* Etiqueta del modo de snap durante el drag */
+.ed-chord.dragging[data-snap-mode]::after {
+  content: attr(data-snap-mode); position: absolute; top: -16px; left: 50%; transform: translateX(-50%);
+  background: var(--accent); color: white; font-size: 9px; padding: 1px 5px; border-radius: 8px;
+  text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
+}
+.ed-chord.dragging[data-snap-mode="word"]::after { content: "palabra"; }
+.ed-chord.dragging[data-snap-mode="syl"]::after { content: "sílaba (shift)"; background: var(--info); }
+.ed-chord.dragging[data-snap-mode="free"]::after { content: "libre (alt)"; background: var(--todo); }
+
+/* Indicador del snap target: la letra donde caerá el acorde */
+.ed-char.snap-hover {
+  background: rgba(37, 99, 235, 0.25); border-radius: 2px;
+  box-shadow: 0 2px 0 var(--accent);
+}
+
+/* Inicio de sílaba/palabra: visible al hover sobre la línea */
+.ed-line.ed-lyric .ed-char.ed-syllable-start { position: relative; }
+.ed-line.ed-lyric:hover .ed-char.ed-syllable-start:not(.ed-word-start)::before {
+  content: '·'; position: absolute; left: -2px; top: -10px; color: var(--fg-3);
+  font-size: 12px; line-height: 1; pointer-events: none; opacity: 0.6;
+}
+.ed-line.ed-lyric:hover .ed-char.ed-word-start::before {
+  content: '|'; position: absolute; left: -2px; top: -9px; color: var(--info);
+  font-size: 8px; line-height: 1; pointer-events: none; opacity: 0.6;
+}
 
 /* Preview render */
 .preview-render { font-family: Georgia, serif; line-height: 1.8; }

--- a/scripts/docx2chordpro.py
+++ b/scripts/docx2chordpro.py
@@ -451,6 +451,83 @@ def word_start_indices(text: str) -> List[int]:
     return starts
 
 
+# ─────────── Silabeado español sencillo ─────────── #
+# Mismas reglas que el silabeado del editor visual (app.js):
+#   V-CV  ·  V-C·CV (con grupos inseparables br/pr/tr/bl/cl/... como excepción)
+_SP_STRONG = set("aeoáéó")
+_SP_WEAK_UNACC = set("iuü")
+_SP_WEAK_ACC = set("íú")
+_SP_VOW = _SP_STRONG | _SP_WEAK_UNACC | _SP_WEAK_ACC
+_SP_INSEP = {"pr", "br", "tr", "dr", "cr", "gr", "fr",
+             "pl", "bl", "cl", "gl", "fl", "ch", "ll", "rr"}
+
+
+def _is_vow(ch: str) -> bool:
+    return ch.lower() in _SP_VOW
+
+
+def syllable_starts_in_word(word: str) -> List[int]:
+    """Índices (relativos al inicio de la palabra) donde empieza cada sílaba."""
+    if not word:
+        return [0]
+    w = word.lower()
+    starts = [0]
+    i = 0
+    while i < len(w):
+        # saltar consonantes iniciales (forman parte de la sílaba actual)
+        while i < len(w) and not _is_vow(w[i]):
+            i += 1
+        # saltar el núcleo vocálico (diptongo/hiato → tratado como uno solo)
+        while i < len(w) and _is_vow(w[i]):
+            i += 1
+        c_start = i
+        # cluster consonántico hasta la siguiente vocal
+        while i < len(w) and not _is_vow(w[i]):
+            i += 1
+        if i >= len(w):
+            break  # palabra acaba en consonantes
+        cluster = w[c_start:i]
+        if len(cluster) == 0:
+            next_syl = i
+        elif len(cluster) == 1:
+            next_syl = c_start                                 # V-CV
+        elif len(cluster) == 2:
+            next_syl = c_start if cluster in _SP_INSEP else c_start + 1
+        else:
+            last2 = cluster[-2:]
+            next_syl = i - 2 if last2 in _SP_INSEP else i - 1
+        if next_syl > starts[-1]:
+            starts.append(next_syl)
+    return starts
+
+
+def syllable_anchor_indices(lyric: str) -> List[int]:
+    """Índices absolutos donde empieza cada sílaba en la línea entera.
+    Añade además 0 y len(lyric) para acordes que caen al principio o final."""
+    if not lyric:
+        return [0]
+    anchors: List[int] = []
+    wstart = -1
+    for i in range(len(lyric)):
+        ch = lyric[i]
+        if ch.isspace():
+            if wstart >= 0:
+                word = lyric[wstart:i]
+                for s in syllable_starts_in_word(word):
+                    anchors.append(wstart + s)
+                wstart = -1
+        else:
+            if wstart == -1:
+                wstart = i
+    if wstart >= 0:
+        word = lyric[wstart:]
+        for s in syllable_starts_in_word(word):
+            anchors.append(wstart + s)
+    anchors.append(0)
+    anchors.append(len(lyric))
+    return sorted(set(anchors))
+
+
 def snap_to_word_start(precise_idx: int, lyric_text: str,
                        char_positions: List[float], chord_x: float) -> int:
     """Snap el índice al inicio de palabra más cercano en PÍXELES.
@@ -458,21 +535,38 @@ def snap_to_word_start(precise_idx: int, lyric_text: str,
     starts = word_start_indices(lyric_text)
     if not starts:
         return precise_idx
-    # candidate: cada inicio de palabra + final de línea (para acordes que caen al final)
     candidates = list(starts) + [len(lyric_text)]
     best = min(candidates, key=lambda s: abs(char_positions[s] - chord_x))
     return best
 
 
+# Umbral de píxeles para considerar que dos acordes "están juntos" y deben
+# apilarse en la misma ancla en lugar de repartirse a sílabas distintas.
+# 30 px ≈ ancho de una sílaba corta en Calibri 12pt @ 96 dpi.
+CHORD_STACK_THRESHOLD_PX = 30.0
+
+# Bonus en píxeles para preferir un inicio de palabra frente a un inicio de
+# sílaba mid-word. Con 10 px, la sílaba tiene que estar al menos 10 px más cerca
+# que la palabra para ganar. Reproduce la convención del cantoral de poner casi
+# todos los acordes en inicio de palabra, salvo cuando claramente caen mid-word.
+WORD_PREFERENCE_PX = 10.0
+
+
 def inject_chords(lyric_text: str, char_positions: List[float],
                   chord_positions: List[Tuple[float, str]]) -> str:
     """Inserta los acordes traducidos en la letra. Conserva el texto tal cual.
+
     Política:
-      - Snap al inicio de palabra más cercano en píxeles.
-      - Si dos acordes (de tokens diferentes) caen en la misma palabra, se hace
-        un "spread": el segundo acorde busca el siguiente inicio de palabra libre.
-      - Los acordes derivados de un único token con guiones (ej. "DO-mim-lam")
-        se mantienen apilados en la misma posición, que es lo esperado.
+      - Híbrido palabra/sílaba: por defecto prefiere inicio de PALABRA; solo
+        usa inicio de sílaba (mid-word) cuando el acorde cae claramente dentro
+        de una palabra (>= WORD_PREFERENCE_PX más cerca de una sílaba que del
+        inicio de palabra). Esto reproduce la convención del cantoral, que pone
+        casi todos los acordes en inicio de palabra pero ocasionalmente en
+        mitad ("VE[C]NID", "LE[C]VAN[Em]TA").
+      - Si dos acordes caen muy cerca en píxeles (< CHORD_STACK_THRESHOLD_PX),
+        se apilan en la misma ancla; si están más separados se reparten en
+        sílabas contiguas para no perder información.
+      - Los acordes de un token con guiones ("DO-mim-lam") se apilan siempre.
     """
     if not chord_positions:
         return lyric_text
@@ -483,20 +577,38 @@ def inject_chords(lyric_text: str, char_positions: List[float],
             chunks.append("".join(f"[{c}]" for c in chords))
         return " ".join(chunks)
 
-    word_starts = word_start_indices(lyric_text)
-    candidates = sorted(set(word_starts + [0, len(lyric_text)]),
-                        key=lambda s: char_positions[s])
+    word_anchors = sorted(set(word_start_indices(lyric_text) + [0, len(lyric_text)]))
+    syl_anchors = syllable_anchor_indices(lyric_text)
+
+    def pick_anchor(x: float, forbidden: set) -> int:
+        """Elige la mejor ancla para un acorde en pixel x, evitando 'forbidden'."""
+        def best_in(candidates):
+            avail = [c for c in candidates if c not in forbidden]
+            if not avail:
+                avail = candidates
+            return min(avail, key=lambda c: abs(char_positions[c] - x))
+        w_best = best_in(word_anchors)
+        s_best = best_in(syl_anchors)
+        w_dist = abs(char_positions[w_best] - x)
+        s_dist = abs(char_positions[s_best] - x)
+        # Si la palabra está dentro de WORD_PREFERENCE_PX de tan buena
+        # como la sílaba, gana la palabra (output más limpio).
+        if w_dist <= s_dist + WORD_PREFERENCE_PX:
+            return w_best
+        return s_best
 
     insertions: Dict[int, List[str]] = {}
-    claimed: set = set()
+    claimed_x: Dict[int, float] = {}  # ancla → x del primer acorde que la ocupó
     for x, tok in sorted(chord_positions, key=lambda p: p[0]):
         chords = translate_chord_token(tok) or [tok]
-        unclaimed = [c for c in candidates if c not in claimed]
-        if unclaimed:
-            idx = min(unclaimed, key=lambda c: abs(char_positions[c] - x))
-        else:
-            idx = min(candidates, key=lambda c: abs(char_positions[c] - x))
-        claimed.add(idx)
+        idx = pick_anchor(x, forbidden=set())
+        if idx in claimed_x:
+            # Ya ocupada: apilar si están juntos, si no, repartir
+            if abs(x - claimed_x[idx]) < CHORD_STACK_THRESHOLD_PX:
+                pass  # apilar — usamos el mismo idx
+            else:
+                idx = pick_anchor(x, forbidden=set(claimed_x.keys()))
+        claimed_x.setdefault(idx, x)
         insertions.setdefault(idx, []).extend(f"[{c}]" for c in chords)
 
     out: List[str] = []


### PR DESCRIPTION
Segunda tanda de mejoras sobre la base que ya se fusionó en #9. Continúa en la misma rama, son 2 commits encima de lo ya mergeado.

## Parser docx → ChordPro (`scripts/docx2chordpro.py`)

Mejora la colocación de acordes en cada importación nueva del cantoral.

- **Silabeado español** añadido al parser (mismas reglas que el editor visual): V-CV, V-C·CV, grupos inseparables `br/pr/tr/bl/cl/ch/ll/rr/...`, diptongos/hiatos simplificados. Probado con `venid/benditos/levanta/iglesia/consolacion/palabras/transporte`.
- **Híbrido palabra/sílaba** en `inject_chords`:
  - Por defecto prefiere inicio de **palabra** (más limpio, coincide con la convención del cantoral).
  - Solo cambia a inicio de **sílaba** cuando el acorde cae claramente mid-word: `WORD_PREFERENCE_PX = 10 px` de sesgo a la palabra; la sílaba tiene que estar al menos 10 px más cerca para ganar.
- **Umbral para apilar acordes** (`CHORD_STACK_THRESHOLD_PX = 30 px`): si dos acordes están más cerca entre sí que el umbral se apilan en la misma ancla en vez de repartirse a sílabas distintas. Esto evita el "spread" agresivo que separaba acordes visualmente clusterizados (cambios rápidos sobre la misma sílaba).

Resultado en canciones conocidas:
- `Ven a Celebrar`: `[G]VEN ... [Bm]AMOR ... [C]SE ... [G]AGUA` coincide con la transcripción manual.
- `Dios Está Aquí`: `[G]` correctamente en TA mid-ESTA gracias al snap por sílaba; el resto en inicio de palabra.
- `[C][Em][Am]` (DO-mim-lam) se apila correctamente en la palabra destino.

## Editor visual (`scripts/admin/static/`)

Cinco mejoras visibles al abrir cualquier canción:

1. **Web font Carlito** (clon métrico libre de Calibri) cargado desde Google Fonts. El editor renderiza con las mismas anchuras de carácter que el parser usó para calcular las posiciones, así que los acordes caen pixel-fiel.
2. **Apilado correcto de acordes** en la misma posición. Antes varios acordes en el mismo índice (`[C][Em][Am]VANTA`) se solapaban en pantalla. Ahora `layoutChords` los agrupa por posición y los pinta en cascada a la derecha del carácter target con gap de 3px.
3. **Indicador de snap en vivo durante el drag**:
   - La letra donde caerá el acorde se resalta con fondo azul y subrayado.
   - El acorde lleva una etiqueta encima (`PALABRA` / `SÍLABA` / `LIBRE`) que cambia con los modificadores que mantengas pulsados.
4. **Separadores de sílaba al hover**. Al pasar el ratón sobre una línea aparecen:
   - Puntos grises `·` en los inicios de sílaba.
   - Barras azules `|` en los inicios de palabra.
   - Desaparecen al quitar el cursor, no estorban la lectura.
5. **Ancla left-aligned** del acorde (sin `translateX(-50%)`). Convención estándar de chord sheets y compatible con el apilado horizontal.

Modal de ayuda actualizado con todas las nuevas interacciones explicadas.

## Commits incluidos

- `a75c359` — feat(parser): híbrido palabra/sílaba con sesgo, umbral para apilar acordes
- `72b1f2c` — feat(admin): editor visual — Carlito, apilado de acordes, indicador snap, sílabas al hover


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFyGDDejkb5K2zukbqDnAJ)_