### PR TITLE
Rediseña sistema de marcado de revisión: dos estados exclusivos + bulk

### DIFF
--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -575,6 +575,50 @@ def api_docx_import():
     return jsonify({"results": results})
 
 
+def _apply_status_to_content(content: str, status: Optional[str]) -> str:
+    """Quita ambos markers de revisión e inserta el nuevo si procede."""
+    lines = content.split('\n')
+    # Strip ambos markers
+    lines = [ln for ln in lines if not (
+        re.search(r'\{\s*comment\s*:[^}]*\bTO\s+DO\b[^}]*\}', ln, re.IGNORECASE) or
+        re.search(r'\{\s*comment\s*:[^}]*♩\s*REVISAR\s*ACORDES[^}]*\}', ln, re.IGNORECASE)
+    )]
+    if status in ("revisar", "revisar_acordes"):
+        marker = TODO_COMMENT_LINE if status == "revisar" else CHORD_REVIEW_COMMENT_LINE
+        # Insertar después del último metadato (title/artist/key/capo/comment al inicio)
+        insert_at = 0
+        for i, ln in enumerate(lines):
+            if re.match(r'^\{(title|comment|artist|author|key|capo)', ln, re.IGNORECASE):
+                insert_at = i + 1
+            elif ln.strip() == '' and insert_at > 0:
+                break
+        lines.insert(insert_at, marker)
+    return '\n'.join(lines)
+
+
+@app.route("/api/songs/bulk-status", methods=["POST"])
+def api_songs_bulk_status():
+    """Establece el estado de revisión de varias canciones de golpe."""
+    data = request.get_json(silent=True) or {}
+    paths = data.get("paths", [])
+    status = data.get("status")  # "revisar" | "revisar_acordes" | None
+    if status not in ("revisar", "revisar_acordes", None):
+        abort(400, "status debe ser 'revisar', 'revisar_acordes' o null")
+    results = []
+    for path_str in paths:
+        try:
+            p = safe_relpath(path_str)
+            content = p.read_text(encoding="utf-8")
+            new_content = _apply_status_to_content(content, status)
+            if new_content != content:
+                backup_file(p)
+                p.write_text(new_content, encoding="utf-8")
+            results.append({"path": path_str, "ok": True})
+        except Exception as e:
+            results.append({"path": path_str, "ok": False, "error": str(e)})
+    return jsonify({"ok": True, "results": results})
+
+
 # ─────────── API: reordenar y build-json ─────────── #
 
 

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -417,11 +417,11 @@ function app() {
           });
           const ln = self.editor.parsed[dragState.lineIdx];
           if (eventLikeEv.altKey) {
-            return bestIdx;  // sin snap
+            return bestIdx;  // sin snap — libre
           } else if (eventLikeEv.shiftKey) {
-            return snapToSyllable(bestIdx, ln.lyric);
+            return snapToWordStart(bestIdx, ln.lyric);  // shift → palabra
           } else {
-            return snapToWordStart(bestIdx, ln.lyric);
+            return snapToSyllable(bestIdx, ln.lyric);   // por defecto → sílaba
           }
         }
 
@@ -436,7 +436,7 @@ function app() {
             const snapIdx = computeSnapIdx(e);
             self.highlightSnapTarget(dragState.lineIdx, snapIdx);
             // Etiqueta del modo activo
-            el.dataset.snapMode = e.altKey ? 'free' : (e.shiftKey ? 'syl' : 'word');
+            el.dataset.snapMode = e.altKey ? 'free' : (e.shiftKey ? 'word' : 'syl');
           }
         }
         function onUp(e) {

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -15,9 +15,9 @@ function app() {
     // Catalog filters
     categoryFilter: '',
     search: '',
-    todoFilter: false,
-    chordReviewFilter: false,
+    statusFilter: '',       // '' | 'revisar' | 'revisar_acordes' | 'any' | 'none'
     onlyInRepoFilter: false,
+    selectedCatalogPaths: new Set(),
 
     // Import view
     importSearch: '',
@@ -107,8 +107,10 @@ function app() {
       if (!this.data) return [];
       let list = this.data.repo_songs;
       if (this.categoryFilter) list = list.filter(r => r.category_letter === this.categoryFilter);
-      if (this.todoFilter) list = list.filter(r => r.has_todo);
-      if (this.chordReviewFilter) list = list.filter(r => r.has_chord_review);
+      if (this.statusFilter === 'revisar')         list = list.filter(r => r.has_todo);
+      else if (this.statusFilter === 'revisar_acordes') list = list.filter(r => r.has_chord_review);
+      else if (this.statusFilter === 'any')         list = list.filter(r => r.has_todo || r.has_chord_review);
+      else if (this.statusFilter === 'none')        list = list.filter(r => !r.has_todo && !r.has_chord_review);
       if (this.onlyInRepoFilter) list = list.filter(r => !r.in_docx);
       if (this.search) {
         const q = this.normalizeSearch(this.search);
@@ -811,37 +813,66 @@ function app() {
         alert('Error: ' + e.message);
       }
     },
-    markReviewed() {
-      // Remove the TO DO comment line
-      const lines = this.editor.content.split('\n');
-      const filtered = lines.filter(ln => !/\{\s*comment\s*:[^}]*\bTO\s+DO\b[^}]*\}/i.test(ln));
-      if (filtered.length !== lines.length) {
-        this.editor.content = filtered.join('\n');
-        this.editor.dirty = true;
-        this.editor.meta.has_todo = false;
-      }
+    // ─────────── Estado de revisión (editor individual) ───────────
+    editorStatus() {
+      if (this.editor.meta.has_todo) return 'revisar';
+      if (this.editor.meta.has_chord_review) return 'revisar_acordes';
+      return null;
     },
-    markChordReview() {
-      if (this.editor.meta.has_chord_review) return;
-      const lines = this.editor.content.split('\n');
-      // Insertar después del primer bloque de metadatos
-      let insertAt = 0;
-      for (let i = 0; i < lines.length; i++) {
-        if (/^\{(title|comment|artist|author|key|capo)/i.test(lines[i])) insertAt = i + 1;
-        else if (lines[i].trim() === '' && insertAt > 0) break;
+    setEditorStatus(status) {
+      // Quita ambos markers y añade el que corresponde
+      let lines = this.editor.content.split('\n');
+      lines = lines.filter(ln =>
+        !/\{\s*comment\s*:[^}]*\bTO\s+DO\b[^}]*\}/i.test(ln) &&
+        !/\{\s*comment\s*:[^}]*♩\s*REVISAR\s*ACORDES[^}]*\}/i.test(ln)
+      );
+      if (status === 'revisar' || status === 'revisar_acordes') {
+        const marker = status === 'revisar'
+          ? '{comment: TO DO: PENDIENTE REVISIÓN ACORDES}'
+          : '{comment: ♩ REVISAR ACORDES}';
+        let insertAt = 0;
+        for (let i = 0; i < lines.length; i++) {
+          if (/^\{(title|comment|artist|author|key|capo)/i.test(lines[i])) insertAt = i + 1;
+          else if (lines[i].trim() === '' && insertAt > 0) break;
+        }
+        lines.splice(insertAt, 0, marker);
       }
-      lines.splice(insertAt, 0, '{comment: ♩ REVISAR ACORDES}');
       this.editor.content = lines.join('\n');
       this.editor.dirty = true;
-      this.editor.meta.has_chord_review = true;
+      this.editor.meta.has_todo = status === 'revisar';
+      this.editor.meta.has_chord_review = status === 'revisar_acordes';
     },
-    unmarkChordReview() {
-      const lines = this.editor.content.split('\n');
-      const filtered = lines.filter(ln => !/\{\s*comment\s*:[^}]*♩\s*REVISAR\s*ACORDES[^}]*\}/i.test(ln));
-      if (filtered.length !== lines.length) {
-        this.editor.content = filtered.join('\n');
-        this.editor.dirty = true;
-        this.editor.meta.has_chord_review = false;
+
+    // ─────────── Selección bulk en catálogo ───────────
+    toggleCatalogSelect(path) {
+      if (this.selectedCatalogPaths.has(path)) this.selectedCatalogPaths.delete(path);
+      else this.selectedCatalogPaths.add(path);
+      this.selectedCatalogPaths = new Set(this.selectedCatalogPaths);
+    },
+    selectAllCatalog() {
+      this.selectedCatalogPaths = new Set(this.filteredRepoSongs().map(r => r.path));
+    },
+    clearCatalogSelect() {
+      this.selectedCatalogPaths = new Set();
+    },
+    async bulkSetStatus(status) {
+      const n = this.selectedCatalogPaths.size;
+      if (n === 0) return;
+      const label = status === 'revisar' ? 'Revisar canción'
+                  : status === 'revisar_acordes' ? 'Revisar acordes'
+                  : 'Sin revisión pendiente';
+      if (!confirm(`¿Marcar ${n} canción(es) como "${label}"?`)) return;
+      try {
+        const r = await fetch('/api/songs/bulk-status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ paths: [...this.selectedCatalogPaths], status: status || null }),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        this.selectedCatalogPaths = new Set();
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error: ' + e.message);
       }
     },
 

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -429,7 +429,7 @@
             <div class="chuleta-row"><span class="chuleta-key">📥 Pegar</span> aplica al destino</div>
             <div class="chuleta-row"><span class="chuleta-key">Ctrl+S</span> guardar</div>
             <div class="chuleta-row"><span class="chuleta-key">2×click acorde</span> editar texto</div>
-            <div class="chuleta-row"><span class="chuleta-key">drag acorde</span> mover · Shift=sílaba · Alt=libre</div>
+            <div class="chuleta-row"><span class="chuleta-key">drag acorde</span> sílaba · Shift=palabra · Alt=libre</div>
           </div>
         </div>
 
@@ -541,8 +541,8 @@
           <h3>Editor visual</h3>
           <table class="kbd-help">
             <tr><th>Arrastrar acorde</th><td>Mueve el acorde. Durante el drag verás en azul la letra donde caerá y una etiqueta del modo (PALABRA/SÍLABA/LIBRE).</td></tr>
-            <tr><th>(sin modificador)</th><td>Snap al inicio de <strong>palabra</strong> más cercano.</td></tr>
-            <tr><th><kbd>Shift</kbd> al soltar</th><td>Snap a inicio de <strong>sílaba</strong> (silabeado español).</td></tr>
+            <tr><th>(sin modificador)</th><td>Snap al inicio de <strong>sílaba</strong> más cercano (silabeado español).</td></tr>
+            <tr><th><kbd>Shift</kbd> al soltar</th><td>Snap a inicio de <strong>palabra</strong>.</td></tr>
             <tr><th><kbd>Alt</kbd> al soltar</th><td>Sin snap — colocación libre carácter a carácter (pixel-perfect).</td></tr>
             <tr><th>Hover sobre línea</th><td>Muestra puntos grises (<code>·</code>) en los inicios de sílaba y barras azules en los inicios de palabra, para ver visualmente dónde puedes anclar.</td></tr>
             <tr><th>Doble-click acorde</th><td>Edita texto del acorde (vacío = borrar).</td></tr>

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -78,11 +78,11 @@
         <div class="stat-val" x-text="data.stats.missing_from_repo"></div>
         <div class="stat-lbl">faltan en el repo</div>
       </div>
-      <div class="stat todo">
+      <div class="stat todo" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar'">
         <div class="stat-val" x-text="data.stats.todo_count"></div>
-        <div class="stat-lbl">con TO DO pendiente</div>
+        <div class="stat-lbl">📝 pendientes revisar canción</div>
       </div>
-      <div class="stat chord-review">
+      <div class="stat chord-review" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar_acordes'">
         <div class="stat-val" x-text="data.stats.chord_review_count"></div>
         <div class="stat-lbl">🎵 pendientes revisar acordes</div>
       </div>
@@ -93,8 +93,7 @@
     </div>
     <div class="actions-row">
       <button class="btn primary" @click="view = 'import'">📥 Importar del cantoral</button>
-      <button class="btn" @click="view = 'catalog'; todoFilter = true">📝 Ver pendientes de revisión</button>
-      <button class="btn" @click="view = 'catalog'; chordReviewFilter = true">🎵 Ver pendientes acordes</button>
+      <button class="btn" @click="view = 'catalog'; statusFilter = 'any'">📋 Ver todas las pendientes</button>
       <button class="btn" @click="openNewSongModal()">➕ Nueva canción a mano</button>
     </div>
 
@@ -121,41 +120,59 @@
 
     <div class="filter-bar">
       <input type="search" placeholder="Buscar título o autor…" x-model="search" />
-      <label><input type="checkbox" x-model="todoFilter" /> Solo TO DO</label>
-      <label><input type="checkbox" x-model="chordReviewFilter" /> 🎵 Revisar acordes</label>
-      <label><input type="checkbox" x-model="onlyInRepoFilter" /> Solo manuales (no en cantoral)</label>
-      <button @click="search = ''; todoFilter = false; chordReviewFilter = false; onlyInRepoFilter = false; categoryFilter = ''">Limpiar</button>
+      <select x-model="statusFilter" class="status-filter-select">
+        <option value="">Todas las canciones</option>
+        <option value="any">Con revisión pendiente</option>
+        <option value="revisar">📝 Pendiente revisar canción</option>
+        <option value="revisar_acordes">🎵 Pendiente revisar acordes</option>
+        <option value="none">✅ Sin revisión pendiente</option>
+      </select>
+      <label><input type="checkbox" x-model="onlyInRepoFilter" /> Solo manuales</label>
+      <button @click="search=''; statusFilter=''; onlyInRepoFilter=false; categoryFilter=''; clearCatalogSelect()">Limpiar</button>
       <span class="count" x-text="filteredRepoSongs().length + ' canciones'"></span>
+    </div>
+
+    <!-- Bulk action bar -->
+    <div class="bulk-bar" x-show="selectedCatalogPaths.size > 0" x-cloak>
+      <span class="bulk-count" x-text="selectedCatalogPaths.size + ' seleccionada(s)'"></span>
+      <button class="btn-mini" @click="bulkSetStatus('revisar')">📝 Marcar revisar canción</button>
+      <button class="btn-mini" @click="bulkSetStatus('revisar_acordes')">🎵 Marcar revisar acordes</button>
+      <button class="btn-mini" @click="bulkSetStatus(null)">✅ Quitar revisión</button>
+      <button class="btn-mini" @click="selectAllCatalog()">Seleccionar todas (<span x-text="filteredRepoSongs().length"></span>)</button>
+      <button class="btn-mini" @click="clearCatalogSelect()">✕ Deseleccionar</button>
     </div>
 
     <table class="songs">
       <thead>
         <tr>
-          <th></th>
-          <th>#</th>
+          <th style="width:28px"><input type="checkbox"
+            :checked="selectedCatalogPaths.size > 0 && filteredRepoSongs().every(r => selectedCatalogPaths.has(r.path))"
+            @change="$event.target.checked ? selectAllCatalog() : clearCatalogSelect()" /></th>
+          <th style="width:36px">#</th>
           <th>Título</th>
           <th>Autor</th>
-          <th>Tono</th>
-          <th>Capo</th>
-          <th>Categoría</th>
+          <th style="width:46px">Tono</th>
+          <th style="width:90px">Categoría</th>
+          <th style="width:130px">Estado revisión</th>
           <th>Acciones</th>
         </tr>
       </thead>
       <tbody>
         <template x-for="r in filteredRepoSongs()" :key="r.path">
-          <tr>
+          <tr :class="{'selected-row': selectedCatalogPaths.has(r.path)}">
+            <td><input type="checkbox" :checked="selectedCatalogPaths.has(r.path)" @change="toggleCatalogSelect(r.path)" /></td>
+            <td style="color:var(--fg-3);font-size:11px" x-text="r.number"></td>
             <td>
-              <span class="badge ok" x-show="r.in_docx" title="También en el cantoral">✅</span>
-              <span class="badge info" x-show="!r.in_docx" title="Solo en repo (manual)">➕</span>
-              <span class="badge todo" x-show="r.has_todo" title="TO DO pendiente revisión">📝</span>
-              <span class="badge chord-review" x-show="r.has_chord_review" title="Pendiente revisar acordes">🎵</span>
+              <a href="#" @click.prevent="openEditor(r.path)" x-text="r.title"></a>
+              <span x-show="!r.in_docx" class="badge-manual" title="Solo en repo, no en cantoral">manual</span>
             </td>
-            <td x-text="r.number"></td>
-            <td><a href="#" @click.prevent="openEditor(r.path)" x-text="r.title"></a></td>
-            <td x-text="r.artist"></td>
-            <td x-text="r.key"></td>
-            <td x-text="r.capo || ''"></td>
-            <td x-text="r.category_letter + '. ' + r.category_folder.replace(/^[A-Z+\d]+\.\s*/, '')"></td>
+            <td style="color:var(--fg-2)" x-text="r.artist"></td>
+            <td style="font-family:monospace;font-size:12px" x-text="r.key"></td>
+            <td style="font-size:12px;color:var(--fg-3)" x-text="r.category_letter"></td>
+            <td>
+              <span class="status-pill status-revisar" x-show="r.has_todo">📝 Revisar</span>
+              <span class="status-pill status-acordes" x-show="r.has_chord_review">🎵 Acordes</span>
+            </td>
             <td>
               <button class="btn-mini" @click="openEditor(r.path)">Editar</button>
               <button class="btn-mini danger" @click="deleteSong(r)">Borrar</button>
@@ -361,13 +378,10 @@
       <div class="editor-header">
         <h2>
           <span x-text="editor.meta.title || editor.filename"></span>
-          <span class="badge todo" x-show="editor.meta.has_todo">📝 TO DO</span>
-          <span class="badge chord-review" x-show="editor.meta.has_chord_review">🎵 Revisar acordes</span>
+          <span class="status-pill status-revisar" x-show="editor.meta.has_todo">📝 Revisar canción</span>
+          <span class="status-pill status-acordes" x-show="editor.meta.has_chord_review">🎵 Revisar acordes</span>
         </h2>
         <div class="editor-actions">
-          <button x-show="editor.meta.has_todo" class="btn" @click="markReviewed()">✓ Revisada</button>
-          <button x-show="!editor.meta.has_chord_review" class="btn" @click="markChordReview()">🎵 Marcar revisar acordes</button>
-          <button x-show="editor.meta.has_chord_review" class="btn primary" @click="unmarkChordReview()">✓ Acordes revisados</button>
           <button class="btn primary" :disabled="!editor.dirty" @click="saveSong()">💾 Guardar</button>
           <button class="btn" @click="closeEditor()">✕ Cerrar</button>
         </div>
@@ -393,6 +407,17 @@
           <input type="text" x-model="editor.meta.key" @input="updateMetaInRaw('key', $event.target.value)" />
           <label>Capo</label>
           <input type="number" min="0" x-model="editor.meta.capo" @input="updateMetaInRaw('capo', $event.target.value)" />
+          <div class="editor-status-selector">
+            <div class="chuleta-title" style="margin-bottom:6px">Estado de revisión</div>
+            <div class="status-seg">
+              <button class="status-seg-btn" :class="{active: editorStatus() === null}"
+                      @click="setEditorStatus(null)">✅ OK</button>
+              <button class="status-seg-btn status-seg-revisar" :class="{active: editorStatus() === 'revisar'}"
+                      @click="setEditorStatus(editorStatus() === 'revisar' ? null : 'revisar')">📝 Revisar</button>
+              <button class="status-seg-btn status-seg-acordes" :class="{active: editorStatus() === 'revisar_acordes'}"
+                      @click="setEditorStatus(editorStatus() === 'revisar_acordes' ? null : 'revisar_acordes')">🎵 Acordes</button>
+            </div>
+          </div>
           <div class="path-info">
             <small x-text="editor.path"></small>
           </div>

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -162,6 +162,8 @@ table.songs a { color: var(--accent); text-decoration: none; font-weight: 500; }
 table.songs a:hover { text-decoration: underline; }
 table.songs tr.has-warn td { background: #fffbeb; }
 .theme-dark table.songs tr.has-warn td { background: #422006; }
+table.songs tr.selected-row td { background: rgba(37,99,235,0.07); }
+.theme-dark table.songs tr.selected-row td { background: rgba(59,130,246,0.13); }
 
 /* Badges */
 .badge { font-size: 14px; margin-right: 2px; cursor: help; }
@@ -171,6 +173,28 @@ table.songs tr.has-warn td { background: #fffbeb; }
 .badge.chord-review { color: var(--info); }
 .stat.chord-review { border-left: 4px solid var(--info); }
 .warn-cell { font-size: 11px; color: var(--warn); }
+
+/* Status pills */
+.status-pill { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 10px; font-weight: 600; white-space: nowrap; }
+.status-pill.status-revisar { background: rgba(234,88,12,0.12); color: var(--todo); border: 1px solid rgba(234,88,12,0.25); }
+.status-pill.status-acordes { background: rgba(8,145,178,0.1); color: var(--info); border: 1px solid rgba(8,145,178,0.25); }
+.badge-manual { font-size: 10px; background: var(--bg-3); color: var(--fg-3); border-radius: 3px; padding: 0 4px; margin-left: 5px; border: 1px solid var(--border-strong); }
+
+/* Bulk action bar */
+.bulk-bar { display: flex; gap: 8px; align-items: center; padding: 8px 12px; background: rgba(37,99,235,0.08); border: 1px solid rgba(37,99,235,0.2); border-radius: 6px; margin-bottom: 8px; flex-wrap: wrap; }
+.bulk-count { font-size: 13px; font-weight: 600; color: var(--accent); margin-right: 4px; }
+
+/* Status filter select */
+.status-filter-select { padding: 6px 10px; border: 1px solid var(--border-strong); border-radius: 4px; font-size: 13px; background: var(--bg-2); color: var(--fg); }
+
+/* Editor status segmented control */
+.editor-status-selector { margin: 16px 0 12px; padding: 12px; background: var(--bg-3); border-radius: 6px; border: 1px solid var(--border); }
+.status-seg { display: flex; gap: 4px; }
+.status-seg-btn { flex: 1; padding: 5px 4px; font-size: 11px; border: 1px solid var(--border-strong); border-radius: 4px; cursor: pointer; background: var(--bg-2); color: var(--fg-2); text-align: center; transition: all 0.15s; }
+.status-seg-btn:hover { background: var(--bg-3); color: var(--fg); }
+.status-seg-btn.active { background: var(--ok); color: white; border-color: var(--ok); font-weight: 600; }
+.status-seg-revisar.active { background: var(--todo); border-color: var(--todo); }
+.status-seg-acordes.active { background: var(--info); border-color: var(--info); }
 
 /* Import results */
 .import-results { margin-top: 20px; background: var(--bg-2); padding: 16px; border-radius: 6px; border: 1px solid var(--border); }

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -352,8 +352,8 @@ body.adding .ed-char:hover { background: rgba(37, 99, 235, 0.15); cursor: pointe
   background: var(--accent); color: white; font-size: 9px; padding: 1px 5px; border-radius: 8px;
   text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
 }
-.ed-chord.dragging[data-snap-mode="word"]::after { content: "palabra"; }
-.ed-chord.dragging[data-snap-mode="syl"]::after { content: "sílaba (shift)"; background: var(--info); }
+.ed-chord.dragging[data-snap-mode="syl"]::after { content: "sílaba"; }
+.ed-chord.dragging[data-snap-mode="word"]::after { content: "palabra (shift)"; background: var(--info); }
 .ed-chord.dragging[data-snap-mode="free"]::after { content: "libre (alt)"; background: var(--todo); }
 
 /* Indicador del snap target: la letra donde caerá el acorde */


### PR DESCRIPTION
Estados mutuamente exclusivos:
  📝 Revisar canción  → la canción está mal en general (TO DO)
  🎵 Revisar acordes  → solo los acordes necesitan colocación
  ✅ Sin revisión      → OK, ningún marcador

Editor:
  - Selector segmentado [✅ OK | 📝 Revisar | 🎵 Acordes] en el panel de
    metadatos: un clic cambia el estado, clic en el activo lo quita
  - Al cambiar, elimina el otro marcador automáticamente
  - El header solo muestra la pill de estado (sin botones dispersos)

Catálogo:
  - Filtro único <select>: Todas / Con revisión / Revisar canción /
    Revisar acordes / Sin revisión
  - Checkbox por fila y checkbox de cabecera para selección bulk
  - Barra de acciones bulk (aparece al seleccionar): marcar revisar,
    marcar acordes, quitar revisión, seleccionar todas, deseleccionar
  - Columna "Estado revisión" con pills de color
  - Columna categoría reducida (solo letra), autor más claro

Dashboard:
  - Los stats de revisión son clicables y llevan al catálogo filtrado

Backend:
  - POST /api/songs/bulk-status con {paths, status} actualiza
    todas las canciones de golpe con backup individual por canción