### PR TITLE
Add LaTeX import feature with chord transposition support

### DIFF
--- a/scripts/admin/latex_import.py
+++ b/scripts/admin/latex_import.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Escaneo / conversión NO interactiva de archivos LaTeX (.tex) → ChordPro.
+
+Reutiliza la lógica de `tab2chordpro.py` (carpeta padre) pero parchea su
+`translate()` para que NUNCA pregunte por consola (los acordes desconocidos
+se devuelven tal cual y se reportan como aviso).
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import time
+import unicodedata
+from pathlib import Path
+from typing import Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = SCRIPT_DIR.parent
+REPO_DIR = SCRIPTS_DIR.parent
+INPUT_DIR = SCRIPTS_DIR / "input"
+PROCESSED_DIR = INPUT_DIR / "processed"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import tab2chordpro as t2c  # noqa: E402
+
+# ─────────── Parche: translate() sin prompts ─────────── #
+
+_unknown_collected: List[str] = []
+
+
+def _translate_silent(tok: str, line_no: int = 0) -> str:
+    if not tok:
+        return tok
+    t = t2c.clean_chord(tok)
+    if '/' in t:
+        left, right = t.split('/', 1)
+        return _translate_silent(left, line_no) + '/' + _translate_silent(right, line_no)
+    if t in t2c.SP_EN:
+        return t2c.SP_EN[t]
+    if t.lower() in t2c.SP_EN:
+        return t2c.SP_EN[t.lower()]
+    if t2c.CHORD_RE.match(t):
+        return t
+    _unknown_collected.append(tok)
+    return t
+
+
+# Sustituimos la función del módulo (lo usa internamente latex_to_chordpro)
+t2c.translate = _translate_silent
+
+# ─────────── Mapeo de carpetas LaTeX → letra de categoría ─────────── #
+
+LATEX_CATEGORY_MAP: Dict[str, str] = {
+    "entrada": "A",
+    "gloria": "B",
+    "salmos": "C",
+    "aleluya": "D",
+    "ofertorio": "E",
+    "santo": "F",
+    "padrenuestro": "G",
+    "paz": "H",
+    "comunion": "I",
+    "salida": "J",
+    "himnos": "K",
+    "gracias": "L",
+    "alianza": "M",
+    "navidad": "N",
+    "pascua": "O",
+    "adoracion": "X",
+    "estribillos": "Y",
+    "a saber": "Z",
+    "otras": "Z",
+}
+
+
+def latex_category_letter(folder_name: str) -> Optional[str]:
+    return LATEX_CATEGORY_MAP.get((folder_name or "").lower().strip())
+
+
+# ─────────── Conversión de un .tex ─────────── #
+
+def slugify(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s or "")
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s).strip("_")
+    return s or "cancion"
+
+
+def parse_latex_song(tex_path: Path) -> dict:
+    """Convierte un .tex a un dict con metadatos + cuerpo ChordPro (sin guardarlo)."""
+    content = tex_path.read_text(encoding="utf-8")
+
+    title_m = re.search(r"\\beginsong\{([^}]+)\}", content)
+    title = ""
+    if title_m:
+        title = title_m.group(1).replace(r"\\", " — ").strip()
+    if not title:
+        title = tex_path.stem.replace("_", " ").strip().title()
+
+    artist_m = re.search(r"by=\{([^}]+)\}", content)
+    artist = artist_m.group(1).strip() if artist_m else ""
+
+    tono_m = re.search(r"\\\[([A-Ga-g][#b]?m?[^\]\s/]*)", content)
+    tono_raw = tono_m.group(1) if tono_m else ""
+    try:
+        tono = t2c.normalize_key(tono_raw) if tono_raw else ""
+    except Exception:
+        tono = ""
+
+    # Conversión completa del cuerpo (silenciosa)
+    global _unknown_collected
+    _unknown_collected = []
+    try:
+        body, transpose_val, capo_val, musica_val = t2c.latex_to_chordpro(content)
+    except Exception as e:
+        body, transpose_val, capo_val, musica_val = "", "", "", ""
+        _unknown_collected.append(f"<error: {e}>")
+    unknown = sorted(set(_unknown_collected))
+
+    return {
+        "title": title,
+        "artist": artist,
+        "key": tono,
+        "capo": capo_val or "",
+        "transpose": transpose_val or "",
+        "musica": musica_val or "",
+        "body": body or "",
+        "unknown_chords": unknown,
+    }
+
+
+def render_latex_cho(parsed: dict) -> str:
+    """Construye el contenido .cho con cabecera TO DO + metadatos."""
+    todo = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
+    header = [todo, f"{{title: {parsed['title']}}}"]
+    if parsed.get("artist"):
+        header.append(f"{{artist: {parsed['artist']}}}")
+    if parsed.get("musica"):
+        header.append(f"{{comment: Música: {parsed['musica']}}}")
+    if parsed.get("key"):
+        header.append(f"{{key: {parsed['key']}}}")
+    if parsed.get("capo"):
+        header.append(f"{{capo: {parsed['capo']}}}")
+    if parsed.get("transpose"):
+        header.append(f"{{comment: Transpose original LaTeX: {parsed['transpose']}}}")
+    body = parsed.get("body") or ""
+    return "\n".join(header) + "\n\n" + body.rstrip() + "\n"
+
+
+# ─────────── Escaneo de toda la carpeta /input ─────────── #
+
+def scan_latex_files(include_parsed: bool = False) -> List[dict]:
+    """Lista todos los .tex de scripts/input/* (excluye processed/)."""
+    out: List[dict] = []
+    if not INPUT_DIR.exists():
+        return out
+    for cat_dir in sorted(INPUT_DIR.iterdir()):
+        if not cat_dir.is_dir() or cat_dir.name == "processed":
+            continue
+        cat_letter = latex_category_letter(cat_dir.name)
+        for tex in sorted(cat_dir.glob("*.tex")):
+            rel = str(tex.relative_to(REPO_DIR))
+            try:
+                parsed = parse_latex_song(tex)
+            except Exception as e:
+                parsed = {
+                    "title": tex.stem.replace("_", " ").title(),
+                    "artist": "", "key": "", "capo": "", "transpose": "",
+                    "musica": "", "body": "", "unknown_chords": [f"<error: {e}>"],
+                }
+            entry = {
+                "id": rel,
+                "filename": tex.name,
+                "latex_folder": cat_dir.name,
+                "category_letter": cat_letter,
+                "title": parsed["title"],
+                "artist": parsed["artist"],
+                "key": parsed["key"],
+                "capo": parsed["capo"],
+                "transpose": parsed["transpose"],
+                "musica": parsed["musica"],
+                "unknown_chords": parsed["unknown_chords"],
+                "suggested_slug": slugify(tex.stem.replace("_", " ")),
+            }
+            if include_parsed:
+                entry["body"] = parsed["body"]
+            out.append(entry)
+    return out
+
+
+def resolve_tex_path(rel_id: str) -> Path:
+    p = (REPO_DIR / rel_id).resolve()
+    # Seguridad: debe estar bajo INPUT_DIR
+    try:
+        p.relative_to(INPUT_DIR.resolve())
+    except ValueError:
+        raise ValueError("Path fuera de scripts/input")
+    if not p.exists():
+        raise FileNotFoundError(rel_id)
+    return p
+
+
+def move_to_processed(tex_path: Path) -> Path:
+    """Mueve el .tex a scripts/input/processed/ (manteniendo nombre)."""
+    PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+    dest = PROCESSED_DIR / tex_path.name
+    if dest.exists():
+        ts = int(time.time())
+        dest = PROCESSED_DIR / f"{tex_path.stem}.dup-{ts}.tex"
+    shutil.move(str(tex_path), str(dest))
+    return dest

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -45,6 +45,7 @@ IGNORED_FILE = SCRIPT_DIR / "import-ignored.json"
 
 sys.path.insert(0, str(SCRIPTS_DIR))
 import docx2chordpro as d2c  # noqa: E402
+import latex_import as lx  # noqa: E402
 
 # Marca para canciones pendientes de revisar acordes (TO DO con espacio entre TO y DO)
 TODO_COMMENT_LINE = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
@@ -200,6 +201,47 @@ def list_repo_songs(category_letter: Optional[str] = None) -> List[dict]:
     return out
 
 
+# ─────────── LaTeX (input/*.tex) ─────────── #
+
+_latex_cache: Dict[str, object] = {"items": None, "snapshot": None}
+
+
+def _latex_snapshot() -> str:
+    """Devuelve una "huella" de los .tex (paths + mtimes) para invalidar cache."""
+    if not lx.INPUT_DIR.exists():
+        return ""
+    parts: List[str] = []
+    for cat in sorted(lx.INPUT_DIR.iterdir()):
+        if not cat.is_dir() or cat.name == "processed":
+            continue
+        for tex in sorted(cat.glob("*.tex")):
+            parts.append(f"{tex.name}:{int(tex.stat().st_mtime)}:{tex.stat().st_size}")
+    return "|".join(parts)
+
+
+def load_latex_items(force: bool = False) -> List[dict]:
+    snap = _latex_snapshot()
+    if not force and _latex_cache["items"] is not None and _latex_cache["snapshot"] == snap:
+        return _latex_cache["items"]  # type: ignore
+    items = lx.scan_latex_files(include_parsed=False)
+    _latex_cache["items"] = items
+    _latex_cache["snapshot"] = snap
+    return items
+
+
+def find_repo_match(title: str, repo_index: Dict[str, dict]) -> Optional[dict]:
+    return best_match(title_keys(title), repo_index)
+
+
+def build_repo_title_index(repo_songs: List[dict]) -> Dict[str, dict]:
+    idx: Dict[str, dict] = {}
+    for r in repo_songs:
+        for k in title_keys(r["title"]):
+            if k:
+                idx.setdefault(k, r)
+    return idx
+
+
 # ─────────── Cantoral docx ─────────── #
 
 _docx_cache: Dict[str, object] = {"songs": None, "mtime": 0}
@@ -335,6 +377,7 @@ def backup_file(path: Path) -> Path:
 def api_catalog():
     repo_songs = list_repo_songs()
     docx_songs = load_docx_songs()
+    latex_items = load_latex_items()
 
     # Cachear conversiones (caras): solo para usar el title aquí
     docx_convs: Dict[int, dict] = {}
@@ -349,8 +392,15 @@ def api_catalog():
                 "section_letter": s["section_letter"],
             })
 
-    # Marcar repo_songs con si está en docx
+    # Índice latex por título (para detectar duplicados desde el repo / docx)
+    latex_index: Dict[str, dict] = {}
+    for lt in latex_items:
+        for k in title_keys(lt["title"]):
+            latex_index.setdefault(k, lt)
+
+    # Marcar repo_songs con si está en docx y/o en LaTeX
     matched_docx_ids: set = set()
+    matched_latex_ids: set = set()
     for r in repo_songs:
         match = best_match(title_keys(r["title"]), docx_index)
         if match:
@@ -360,6 +410,15 @@ def api_catalog():
         else:
             r["in_docx"] = False
             r["docx_id"] = None
+        lmatch = best_match(title_keys(r["title"]), latex_index)
+        if lmatch:
+            r["in_latex"] = True
+            r["latex_id"] = lmatch["id"]
+            r["latex_title"] = lmatch["title"]
+            matched_latex_ids.add(lmatch["id"])
+        else:
+            r["in_latex"] = False
+            r["latex_id"] = None
 
     # Canciones del docx que NO están en repo (excluidas las archivadas)
     ignored = load_ignored()
@@ -370,6 +429,9 @@ def api_catalog():
         if s["title_raw"] in ignored:
             continue
         conv = docx_convs[s["id"]]
+        # ¿Está disponible esta misma canción en LaTeX? Si sí, avisamos y damos
+        # prioridad a la versión LaTeX (el usuario debería importar de LaTeX, no de docx).
+        latex_alt = best_match(title_keys(conv["title"]), latex_index)
         missing.append({
             "docx_id": s["id"],
             "title": conv["title"],
@@ -378,11 +440,15 @@ def api_catalog():
             "key": conv.get("key"),
             "capo": conv.get("capo"),
             "warnings": conv.get("warnings", []),
+            "latex_available": bool(latex_alt),
+            "latex_id": latex_alt["id"] if latex_alt else None,
         })
 
     # Contadores
     todo_count = sum(1 for r in repo_songs if r["has_todo"])
     chord_review_count = sum(1 for r in repo_songs if r["has_chord_review"])
+    latex_total = len(latex_items)
+    latex_only_new = sum(1 for lt in latex_items if lt["id"] not in matched_latex_ids)
 
     return jsonify({
         "categories": list_categories(),
@@ -395,6 +461,9 @@ def api_catalog():
             "chord_review_count": chord_review_count,
             "missing_from_repo": len(missing),
             "only_in_repo": sum(1 for r in repo_songs if not r["in_docx"]),
+            "latex_total": latex_total,
+            "latex_new": latex_only_new,
+            "latex_matches_repo": len(matched_latex_ids),
         },
     })
 
@@ -573,6 +642,143 @@ def api_docx_import():
             "warnings": conv.get("warnings", []),
         })
     return jsonify({"results": results})
+
+
+# ─────────── API: LaTeX (input/*.tex) ─────────── #
+
+
+@app.route("/api/latex/list")
+def api_latex_list():
+    """Lista todos los .tex de scripts/input/ y los enriquece con la coincidencia
+    en el repo (si la hay) para poder elegir entre crear nueva o sobrescribir.
+    """
+    force = request.args.get("force") == "1"
+    latex_items = load_latex_items(force=force)
+    repo_songs = list_repo_songs()
+    repo_index = build_repo_title_index(repo_songs)
+
+    out = []
+    for lt in latex_items:
+        match = find_repo_match(lt["title"], repo_index)
+        target_letter = lt.get("category_letter")
+        # Si no tenemos mapeo de carpeta pero hay match, usamos la categoría del match
+        if not target_letter and match:
+            target_letter = match["category_letter"]
+        item = dict(lt)
+        item["repo_match"] = None
+        if match:
+            item["repo_match"] = {
+                "path": match["path"],
+                "filename": match["filename"],
+                "number": match["number"],
+                "category_letter": match["category_letter"],
+                "category_folder": match["category_folder"],
+                "title": match["title"],
+            }
+        item["target_letter"] = target_letter
+        out.append(item)
+    # Categorías existentes para que el cliente sepa los nombres legibles
+    cats = list_categories()
+    return jsonify({"items": out, "categories": cats})
+
+
+@app.route("/api/latex/preview")
+def api_latex_preview():
+    rel = request.args.get("id", "")
+    if not rel:
+        abort(400, "Falta id")
+    try:
+        p = lx.resolve_tex_path(rel)
+    except (ValueError, FileNotFoundError) as e:
+        abort(404, str(e))
+    parsed = lx.parse_latex_song(p)
+    raw_tex = p.read_text(encoding="utf-8")
+    return jsonify({
+        "id": rel,
+        "filename": p.name,
+        "latex_raw": raw_tex,
+        "parsed": parsed,
+        "content": lx.render_latex_cho(parsed),
+    })
+
+
+@app.route("/api/latex/import", methods=["POST"])
+def api_latex_import():
+    """Importa los .tex elegidos. Cada item puede ser:
+      - { "id": "scripts/input/.../foo.tex", "mode": "new", "category_letter": "A", "slug": "..." }
+      - { "id": "...", "mode": "overwrite", "repo_path": "songs/A. .../03.foo.cho" }
+    """
+    body = request.get_json(silent=True) or {}
+    items = body.get("items") or []
+    move_processed = body.get("move_to_processed", True)
+    if not isinstance(items, list) or not items:
+        abort(400, "Falta items")
+    results = []
+    for it in items:
+        rel = it.get("id")
+        mode = (it.get("mode") or "new").lower()
+        try:
+            tex_path = lx.resolve_tex_path(rel)
+            parsed = lx.parse_latex_song(tex_path)
+            content = lx.render_latex_cho(parsed)
+
+            if mode == "overwrite":
+                repo_path_str = it.get("repo_path")
+                if not repo_path_str:
+                    raise ValueError("Falta repo_path para overwrite")
+                target = safe_relpath(repo_path_str)
+                if not target.exists():
+                    raise FileNotFoundError(f"No existe destino: {repo_path_str}")
+                backup_file(target)
+                target.write_text(content, encoding="utf-8")
+                final_path = target
+                action = "overwritten"
+            else:
+                cat_letter = (it.get("category_letter") or "").upper()
+                if not cat_letter:
+                    raise ValueError("Falta category_letter")
+                cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
+                if not cat:
+                    raise ValueError(f"Categoría {cat_letter} no encontrada")
+                folder = SONGS_DIR / cat["folder"]
+                folder.mkdir(exist_ok=True)
+                slug = it.get("slug") or parsed.get("suggested_slug") or lx.slugify(parsed["title"])
+                slug = re.sub(r"[^a-z0-9_]+", "_", slug.lower()).strip("_") or "cancion"
+                num = it.get("number")
+                if not (isinstance(num, int) and num > 0):
+                    num = d2c.next_song_number(folder)
+                fname = f"{num:02d}.{slug}.cho"
+                fpath = folder / fname
+                if fpath.exists():
+                    raise FileExistsError(f"Ya existe {fname}")
+                fpath.write_text(content, encoding="utf-8")
+                final_path = fpath
+                action = "created"
+
+            moved_to = None
+            if move_processed:
+                moved = lx.move_to_processed(tex_path)
+                moved_to = str(moved.relative_to(REPO_DIR))
+            results.append({
+                "id": rel,
+                "ok": True,
+                "action": action,
+                "path": str(final_path.relative_to(REPO_DIR)),
+                "moved_to": moved_to,
+                "warnings": parsed.get("unknown_chords", []),
+            })
+        except Exception as e:
+            results.append({"id": rel, "ok": False, "error": str(e)})
+    # Invalidar cache
+    _latex_cache["snapshot"] = None
+    return jsonify({"results": results})
+
+
+@app.route("/api/latex/rescan", methods=["POST"])
+def api_latex_rescan():
+    _latex_cache["snapshot"] = None
+    load_latex_items(force=True)
+    return jsonify({"ok": True})
 
 
 def _apply_status_to_content(content: str, status: Optional[str]) -> str:

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -51,6 +51,7 @@ function app() {
     visualSelectedLines: new Set(),
     visualLastClickedLine: null,
     visualChordClipboard: null,   // [{lyric, chords}]  patrón copiado
+    clipboardInfo: '',            // texto persistente cuando hay acordes copiados
     showHelp: false,
     newSong: { open: false, category: '', title: '', artist: '', key: '', capo: 0,
                mode: 'blank', content: '', creating: false },
@@ -674,7 +675,10 @@ function app() {
     // ─────────── Copiar / pegar patrón de acordes ───────────
     copyChordPattern() {
       const r = this.selectedLineRange();
-      if (!r) return;
+      if (!r) {
+        alert('Primero selecciona las líneas que tienen los acordes que quieres copiar.\n\n→ Haz click en el círculo ○ del margen IZQUIERDO de cada línea (se pondrá azul ◉).\n→ Luego pulsa "📋 Copiar acordes".');
+        return;
+      }
       const pattern = [];
       for (let i = r.start; i <= r.end; i++) {
         const ln = this.editor.parsed[i];
@@ -688,14 +692,24 @@ function app() {
       if (pattern.length === 0) { alert('No hay líneas de letra en la selección.'); return; }
       this.visualChordClipboard = pattern;
       const total = pattern.reduce((acc, p) => acc + p.chords.length, 0);
-      this.setSaveIndicator('saved', `📋 ${total} acordes copiados — ahora selecciona el destino y pega`);
+      this.clipboardInfo = `📋 ${total} acordes copiados de ${pattern.length} línea(s)`;
       // Limpiar selección para que el usuario seleccione el destino sin mezclar origen
       this.clearLineSelection();
-      setTimeout(() => { if (this.editor.dirty) this.setSaveIndicator('dirty', '● Sin guardar'); else this.setSaveIndicator('saved', 'Sin cambios'); }, 3000);
+    },
+    cancelChordClipboard() {
+      this.visualChordClipboard = null;
+      this.clipboardInfo = '';
     },
     pasteChordPattern() {
+      if (!this.visualChordClipboard) {
+        alert('No tienes acordes copiados todavía. Primero pulsa "📋 Copiar acordes" sobre una estrofa que tenga los acordes que quieras reutilizar.');
+        return;
+      }
       const r = this.selectedLineRange();
-      if (!r || !this.visualChordClipboard) return;
+      if (!r) {
+        alert('Selecciona las líneas DESTINO donde quieres pegar los acordes.\n\n→ Haz click en el círculo ○ del margen izquierdo de cada línea (se pondrá azul ◉).\n→ Luego pulsa "📥 Pegar acordes".');
+        return;
+      }
       // Recoger las líneas de letra de la selección
       const targets = [];
       for (let i = r.start; i <= r.end; i++) {
@@ -719,6 +733,70 @@ function app() {
         this.setSaveIndicator('saved', `✓ ${totalPasted} acordes pegados en ${targets.length} línea(s)`);
         setTimeout(() => { if (this.editor.dirty) this.setSaveIndicator('dirty', '● Sin guardar'); }, 2500);
       });
+      // Mantenemos el clipboard por si quiere pegar en otra estrofa más
+    },
+
+    // Mensaje de ayuda contextual sobre el flujo copiar/pegar
+    copyPasteHint() {
+      const hasSel = this.visualSelectedLines.size > 0;
+      const hasClip = !!this.visualChordClipboard;
+      if (hasClip && hasSel) return '③ Pulsa 📥 Pegar acordes para aplicarlos a las líneas seleccionadas.';
+      if (hasClip && !hasSel) return '② Acordes copiados ✓ — ahora marca las líneas DESTINO con el círculo ○ del margen izquierdo y pulsa 📥 Pegar.';
+      if (!hasClip && hasSel) return '② Pulsa 📋 Copiar acordes para guardar el patrón, luego marca el destino.';
+      return '① Para copiar acordes entre estrofas: marca las líneas ORIGEN haciendo click en el círculo ○ del margen izquierdo, luego pulsa 📋 Copiar.';
+    },
+
+    // ─────────── Transposición de tono ───────────
+    transposeSong(semis) {
+      if (!semis || !this.editor.parsed) return;
+      const target = computeTransposedKey(this.editor.meta.key, semis);
+      const useFlats = target ? target.useFlats : (semis < 0);
+      let count = 0;
+      for (const ln of this.editor.parsed) {
+        if (ln.type === 'lyric' && ln.chords) {
+          ln.chords = ln.chords.map(c => {
+            const nt = transposeChordText(c.text, semis, useFlats);
+            if (nt !== c.text) count++;
+            return { ...c, text: nt };
+          });
+        }
+      }
+      if (target && this.editor.meta.key) {
+        this.editor.meta.key = target.key;
+        this.updateMetaInRaw('key', target.key);
+      }
+      this.editor.parsed = [...this.editor.parsed];
+      this.commitParsed();
+      this.$nextTick(() => this.layoutChords());
+      const dir = semis > 0 ? `+${semis}` : `${semis}`;
+      this.setSaveIndicator('dirty', `🎵 ${count} acordes transpuestos (${dir} semitono${Math.abs(semis) === 1 ? '' : 's'})${target ? ' → ' + target.key : ''} · pulsa 💾 para guardar`);
+    },
+    transposeSongToKey(targetKey) {
+      if (!targetKey) return;
+      const curKey = this.editor.meta.key || '';
+      if (!curKey) {
+        alert('Esta canción no tiene tono indicado en los metadatos. Escribe primero el tono actual (ej. "D") en el campo "Tono (key)" y luego usa "Llevar a".');
+        return;
+      }
+      const curM = curKey.match(/^([A-G])([#b]?)/);
+      const tgtM = targetKey.match(/^([A-G])([#b]?)/);
+      if (!curM || !tgtM) { alert('No reconozco el tono "' + curKey + '" → "' + targetKey + '".'); return; }
+      const curIdx = NOTE_INDEX[curM[1] + curM[2]];
+      const tgtIdx = NOTE_INDEX[tgtM[1] + tgtM[2]];
+      if (curIdx == null || tgtIdx == null) { alert('Tono no reconocido.'); return; }
+      let semis = tgtIdx - curIdx;
+      // dirección más corta
+      if (semis > 6) semis -= 12;
+      if (semis < -6) semis += 12;
+      if (semis === 0) {
+        this.setSaveIndicator('saved', 'La canción ya está en ' + targetKey);
+        return;
+      }
+      this.transposeSong(semis);
+    },
+    commonKeyOptions() {
+      return ['C','C#','Db','D','Eb','E','F','F#','Gb','G','Ab','A','Bb','B',
+              'Cm','C#m','Dm','Ebm','Em','Fm','F#m','Gm','G#m','Am','Bbm','Bm'];
     },
 
     // ─────────── Editar texto de la letra ───────────
@@ -1247,4 +1325,62 @@ function renderChordLine(line) {
     html.push(`<span class="pv-seg"><span class="pv-chords">${pendingChords.map(esc).join(' ')}</span><span class="pv-lyr">${esc(textBuf) || '&nbsp;'}</span></span>`);
   }
   return html.join('');
+}
+
+// ─────────── Transposición de acordes ───────────
+const NOTES_SHARP = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+const NOTES_FLAT  = ['C','Db','D','Eb','E','F','Gb','G','Ab','A','Bb','B'];
+const NOTE_INDEX = {
+  'C':0,'C#':1,'Db':1,'D':2,'D#':3,'Eb':3,'E':4,'Fb':4,'E#':5,
+  'F':5,'F#':6,'Gb':6,'G':7,'G#':8,'Ab':8,'A':9,'A#':10,'Bb':10,
+  'B':11,'Cb':11,'B#':0,
+};
+
+function transposeNoteName(note, semis, useFlats) {
+  const idx = NOTE_INDEX[note];
+  if (idx == null) return note;
+  const arr = useFlats ? NOTES_FLAT : NOTES_SHARP;
+  return arr[((idx + semis) % 12 + 12) % 12];
+}
+
+// Transpone el texto de un acorde (ej. "Dm7/F#" → "Cm7/E"). Conserva todo lo no-nota.
+function transposeChordText(text, semis, useFlats) {
+  if (!text) return text;
+  // Acordes con barras (NC, x, etc) o textos no estándar — los dejamos intactos.
+  const reChord = /^([A-G])([#b]?)([^\/\s]*)(\/([A-G])([#b]?)(.*))?$/;
+  const m = text.match(reChord);
+  if (!m) return text;
+  const newRoot = transposeNoteName(m[1] + (m[2] || ''), semis, useFlats);
+  let out = newRoot + (m[3] || '');
+  if (m[4]) {
+    const newBass = transposeNoteName(m[5] + (m[6] || ''), semis, useFlats);
+    out += '/' + newBass + (m[7] || '');
+  }
+  return out;
+}
+
+// Calcula el nuevo tono después de transponer, eligiendo bemoles o sostenidos
+// según la convención habitual del nuevo tono.
+function computeTransposedKey(key, semis) {
+  if (!key) return null;
+  const m = key.match(/^([A-G])([#b]?)(m?)(.*)$/);
+  if (!m) return null;
+  const isMinor = m[3] === 'm';
+  const suffix = m[4] || '';
+  // Probamos ambos spellings y elegimos
+  const sharpName = transposeNoteName(m[1] + (m[2] || ''), semis, false);
+  const flatName = transposeNoteName(m[1] + (m[2] || ''), semis, true);
+  const FLAT_MAJOR = new Set(['F','Bb','Eb','Ab','Db','Gb','Cb']);
+  const FLAT_MINOR = new Set(['D','G','C','F','Bb','Eb','Ab']);
+  const flatSet = isMinor ? FLAT_MINOR : FLAT_MAJOR;
+  // Si el original venía con bemol y el resultado natural empata, preferimos bemoles
+  const originalHasFlat = (m[2] === 'b');
+  let useFlats;
+  if (sharpName === flatName) {
+    useFlats = originalHasFlat;
+  } else {
+    useFlats = flatSet.has(flatName);
+  }
+  const tonic = useFlats ? flatName : sharpName;
+  return { key: tonic + (isMinor ? 'm' : '') + suffix, useFlats };
 }

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -19,7 +19,7 @@ function app() {
     onlyInRepoFilter: false,
     selectedCatalogPaths: new Set(),
 
-    // Import view
+    // Import view (docx)
     importSearch: '',
     importSectionFilter: '',
     selectedImports: new Set(),
@@ -28,6 +28,19 @@ function app() {
     docxPreview: null,
     importIgnored: [],
     showIgnored: false,
+
+    // Import view (LaTeX)
+    latexItems: [],
+    latexLoading: false,
+    latexSearch: '',
+    latexFolderFilter: '',
+    latexMatchFilter: '',
+    selectedLatex: new Set(),
+    latexImportMode: {},        // { latex_id: 'overwrite' | 'new' }
+    latexCategoryOverride: {},  // { latex_id: 'A' | '' }
+    importingLatex: false,
+    latexResults: [],
+    latexPreview: null,
 
     // Reorder
     reorderCategory: '',
@@ -209,6 +222,142 @@ function app() {
         await Promise.all([this.loadCatalog(), this.loadIgnored()]);
       } catch (e) {
         alert('Error: ' + e.message);
+      }
+    },
+
+    // ─────────── Import view (LaTeX) ───────────
+    async loadLatex(force = false) {
+      this.latexLoading = true;
+      try {
+        const r = await fetch('/api/latex/list' + (force ? '?force=1' : ''));
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        this.latexItems = d.items || [];
+        // Inicializar modo por defecto: si hay match, overwrite; si no, new
+        for (const it of this.latexItems) {
+          if (this.latexImportMode[it.id] == null) {
+            this.latexImportMode[it.id] = it.repo_match ? 'overwrite' : 'new';
+          }
+          if (this.latexCategoryOverride[it.id] == null) {
+            this.latexCategoryOverride[it.id] = '';
+          }
+        }
+      } catch (e) {
+        alert('No pude cargar los .tex: ' + e.message);
+      } finally {
+        this.latexLoading = false;
+      }
+    },
+    async rescanLatex() {
+      await fetch('/api/latex/rescan', { method: 'POST' });
+      await this.loadLatex(true);
+    },
+    latexFolders() {
+      const s = new Set(this.latexItems.map(l => l.latex_folder));
+      return [...s].sort();
+    },
+    filteredLatex() {
+      let list = this.latexItems;
+      if (this.latexFolderFilter) list = list.filter(l => l.latex_folder === this.latexFolderFilter);
+      if (this.latexMatchFilter === 'new') list = list.filter(l => !l.repo_match);
+      else if (this.latexMatchFilter === 'match') list = list.filter(l => !!l.repo_match);
+      else if (this.latexMatchFilter === 'warn') list = list.filter(l => l.unknown_chords.length > 0);
+      if (this.latexSearch) {
+        const q = this.normalizeSearch(this.latexSearch);
+        list = list.filter(l => this.normalizeSearch(l.title).includes(q) || this.normalizeSearch(l.filename).includes(q));
+      }
+      return list;
+    },
+    filterLatexById(id) {
+      this.latexSearch = '';
+      this.latexFolderFilter = '';
+      this.latexMatchFilter = '';
+      // Pequeño truco para destacar visualmente
+      this.$nextTick(() => {
+        const row = document.querySelector(`[data-latex-id="${id}"]`);
+        if (row) row.scrollIntoView({ block: 'center' });
+      });
+    },
+    toggleLatex(id) {
+      if (this.selectedLatex.has(id)) this.selectedLatex.delete(id);
+      else this.selectedLatex.add(id);
+      this.selectedLatex = new Set(this.selectedLatex);
+    },
+    selectAllLatex() {
+      const ids = this.filteredLatex().map(l => l.id);
+      this.selectedLatex = new Set([...this.selectedLatex, ...ids]);
+    },
+    setLatexMode(id, mode) {
+      this.latexImportMode = { ...this.latexImportMode, [id]: mode };
+    },
+    async previewLatex(id) {
+      try {
+        const r = await fetch('/api/latex/preview?id=' + encodeURIComponent(id));
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        this.latexPreview = await r.json();
+      } catch (e) {
+        alert('Error preview: ' + e.message);
+      }
+    },
+    async importOneLatex(id) {
+      this.selectedLatex = new Set([id]);
+      await this.doImportLatex();
+      this.latexPreview = null;
+    },
+    async doImportLatex() {
+      if (this.selectedLatex.size === 0) return;
+      this.importingLatex = true;
+      this.latexResults = [];
+      const items = [];
+      for (const id of this.selectedLatex) {
+        const it = this.latexItems.find(l => l.id === id);
+        if (!it) continue;
+        const mode = this.latexImportMode[id] || (it.repo_match ? 'overwrite' : 'new');
+        if (mode === 'overwrite' && it.repo_match) {
+          items.push({ id, mode: 'overwrite', repo_path: it.repo_match.path });
+        } else {
+          const cat = this.latexCategoryOverride[id] || it.target_letter;
+          if (!cat) {
+            this.latexResults.push({ id, ok: false, error: 'No tiene categoría destino — selecciónala' });
+            continue;
+          }
+          items.push({ id, mode: 'new', category_letter: cat, slug: it.suggested_slug });
+        }
+      }
+      if (items.length === 0) { this.importingLatex = false; return; }
+      try {
+        const r = await fetch('/api/latex/import', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items, move_to_processed: true }),
+        });
+        const json = await r.json();
+        this.latexResults = [...this.latexResults, ...(json.results || [])];
+        this.selectedLatex = new Set();
+        await Promise.all([this.loadCatalog(), this.loadLatex(true)]);
+      } catch (e) {
+        alert('Error importando LaTeX: ' + e.message);
+      } finally {
+        this.importingLatex = false;
+      }
+    },
+    async openSongFromPath(path) {
+      // Reusa la apertura del editor por path
+      try {
+        const r = await fetch('/api/song?path=' + encodeURIComponent(path));
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const json = await r.json();
+        this.editor = {
+          path: json.path, filename: json.filename, content: json.content,
+          originalContent: json.content, dirty: false, tab: 'visual',
+          meta: { ...json.meta }, parsed: [],
+        };
+        this.editor.parsed = parseCho(this.editor.content);
+        this.markChorusFlags();
+        this.setSaveIndicator('saved', '✓ Cargada');
+        this.$nextTick(() => this.layoutChords());
+      } catch (e) {
+        alert('No pude abrir: ' + e.message);
       }
     },
 

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -25,6 +25,7 @@
     <a :class="{active: view === 'dashboard'}" @click.prevent="view = 'dashboard'" href="#">📊 Dashboard</a>
     <a :class="{active: view === 'catalog'}" @click.prevent="view = 'catalog'; categoryFilter = ''" href="#">📋 Catálogo</a>
     <a :class="{active: view === 'import'}" @click.prevent="view = 'import'" href="#">📥 Importar del cantoral</a>
+    <a :class="{active: view === 'latex'}" @click.prevent="view = 'latex'; loadLatex()" href="#">📐 Importar de LaTeX</a>
     <a :class="{active: view === 'reorder'}" @click.prevent="view = 'reorder'" href="#">🔀 Reordenar</a>
     <a :class="{active: view === 'backups'}" @click.prevent="view = 'backups'; loadBackups()" href="#">🗂 Backups</a>
   </nav>
@@ -89,6 +90,10 @@
       <div class="stat info">
         <div class="stat-val" x-text="data.stats.only_in_repo"></div>
         <div class="stat-lbl">solo en repo (manuales)</div>
+      </div>
+      <div class="stat" style="background: rgba(139, 92, 246, 0.10); cursor: pointer" @click="view = 'latex'; loadLatex()">
+        <div class="stat-val" x-text="(data.stats.latex_new || 0) + '/' + (data.stats.latex_total || 0)"></div>
+        <div class="stat-lbl">📐 nuevas / total en LaTeX</div>
       </div>
     </div>
     <div class="actions-row">
@@ -213,14 +218,20 @@
       </thead>
       <tbody>
         <template x-for="m in filteredMissing()" :key="m.docx_id">
-          <tr :class="{ 'has-warn': m.warnings.length > 0 }">
+          <tr :class="{ 'has-warn': m.warnings.length > 0, 'has-latex': m.latex_available }">
             <td>
               <input type="checkbox"
                      :checked="selectedImports.has(m.docx_id)"
                      @change="toggleImport(m.docx_id)" />
             </td>
             <td x-text="m.section_letter"></td>
-            <td><a href="#" @click.prevent="previewDocx(m.docx_id)" x-text="m.title"></a></td>
+            <td>
+              <a href="#" @click.prevent="previewDocx(m.docx_id)" x-text="m.title"></a>
+              <span x-show="m.latex_available"
+                    class="badge-latex"
+                    title="Esta canción también está en LaTeX — se recomienda importarla desde LaTeX (mejor calidad)"
+                    @click.stop="view = 'latex'; loadLatex().then(() => filterLatexById(m.latex_id))">📐 también en LaTeX</span>
+            </td>
             <td x-text="m.key"></td>
             <td x-text="m.capo || ''"></td>
             <td class="warn-cell" x-text="m.warnings.join('; ')"></td>
@@ -275,6 +286,165 @@
       </div>
     </div>
   </section>
+
+  <!-- IMPORTAR LATEX -->
+  <section x-show="view === 'latex' && data" x-cloak>
+    <h1>📐 Importar de LaTeX</h1>
+    <p class="muted">
+      Archivos <code>.tex</code> en <code>scripts/input/&lt;categoría&gt;/</code>.
+      Si el título <strong>coincide con una canción ya existente</strong> en el repo, se ofrece
+      <span class="badge-overwrite">↻ sobrescribir manteniendo número</span> en lugar de crear otra.
+      Tras importar, el <code>.tex</code> se mueve a <code>scripts/input/processed/</code>.
+    </p>
+    <p class="muted" style="font-size:11px">
+      <strong>LaTeX tiene prioridad sobre el cantoral DOCX</strong> — si una canción está en ambos,
+      mejor importarla desde aquí (los acordes vienen ya bien posicionados).
+    </p>
+
+    <div class="filter-bar">
+      <input type="search" placeholder="Buscar…" x-model="latexSearch" />
+      <select x-model="latexFolderFilter">
+        <option value="">Todas las carpetas</option>
+        <template x-for="f in latexFolders()" :key="f">
+          <option :value="f" x-text="f"></option>
+        </template>
+      </select>
+      <select x-model="latexMatchFilter">
+        <option value="">Todas</option>
+        <option value="new">Sólo nuevas (sin coincidencia)</option>
+        <option value="match">Sólo coincidentes con el repo</option>
+        <option value="warn">Con avisos</option>
+      </select>
+      <button @click="selectAllLatex()">Seleccionar todas</button>
+      <button @click="selectedLatex = new Set()">Limpiar selección</button>
+      <button @click="rescanLatex()" title="Volver a leer los .tex">🔄 Re-escanear</button>
+      <button class="btn primary" :disabled="selectedLatex.size === 0 || importingLatex"
+              @click="doImportLatex()"
+              x-text="importingLatex ? 'Importando…' : `Importar ${selectedLatex.size} seleccionadas`"></button>
+    </div>
+
+    <table class="songs">
+      <thead>
+        <tr>
+          <th></th>
+          <th>Carpeta</th>
+          <th>Categoría destino</th>
+          <th>Título (LaTeX)</th>
+          <th>Tono</th>
+          <th>Coincidencia en repo</th>
+          <th>Modo</th>
+          <th>Avisos</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="l in filteredLatex()" :key="l.id">
+          <tr :class="{ 'has-warn': l.unknown_chords.length > 0, 'has-match': !!l.repo_match }">
+            <td>
+              <input type="checkbox"
+                     :checked="selectedLatex.has(l.id)"
+                     @change="toggleLatex(l.id)" />
+            </td>
+            <td x-text="l.latex_folder"></td>
+            <td>
+              <select x-model="latexCategoryOverride[l.id]" class="cat-select-mini"
+                      :disabled="(latexImportMode[l.id] || (l.repo_match ? 'overwrite' : 'new')) === 'overwrite'">
+                <option :value="''" x-text="'auto: ' + (l.target_letter || '?')"></option>
+                <template x-for="cat in data.categories" :key="cat.letter">
+                  <option :value="cat.letter" x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '').slice(0,18)"></option>
+                </template>
+              </select>
+            </td>
+            <td>
+              <a href="#" @click.prevent="previewLatex(l.id)" x-text="l.title"></a>
+              <div class="row-meta" x-show="l.artist" x-text="'— ' + l.artist"></div>
+            </td>
+            <td x-text="l.key || ''"></td>
+            <td>
+              <template x-if="l.repo_match">
+                <div class="repo-match">
+                  <span class="match-num" x-text="'#' + (l.repo_match.number || '?')"></span>
+                  <a href="#" @click.prevent="openSongFromPath(l.repo_match.path)" x-text="l.repo_match.title"></a>
+                  <div class="row-meta" x-text="l.repo_match.category_letter + ' — ' + l.repo_match.filename"></div>
+                </div>
+              </template>
+              <template x-if="!l.repo_match">
+                <span class="muted-mini">— ninguna —</span>
+              </template>
+            </td>
+            <td>
+              <template x-if="l.repo_match">
+                <div class="mode-toggle">
+                  <label>
+                    <input type="radio" :name="'mode-' + l.id" value="overwrite"
+                           :checked="(latexImportMode[l.id] || 'overwrite') === 'overwrite'"
+                           @change="setLatexMode(l.id, 'overwrite')" />
+                    <span class="badge-overwrite">↻ sobrescribir #<span x-text="l.repo_match.number || '?'"></span></span>
+                  </label>
+                  <label>
+                    <input type="radio" :name="'mode-' + l.id" value="new"
+                           :checked="latexImportMode[l.id] === 'new'"
+                           @change="setLatexMode(l.id, 'new')" />
+                    <span>➕ crear nueva</span>
+                  </label>
+                </div>
+              </template>
+              <template x-if="!l.repo_match">
+                <span class="badge-new">➕ nueva</span>
+              </template>
+            </td>
+            <td class="warn-cell">
+              <template x-if="l.unknown_chords.length > 0">
+                <span :title="'Acordes raros: ' + l.unknown_chords.join(', ')">
+                  ⚠ <span x-text="l.unknown_chords.length"></span> acorde(s) revisar
+                </span>
+              </template>
+            </td>
+            <td style="white-space:nowrap">
+              <button class="btn-mini" @click="previewLatex(l.id)">👁 Ver</button>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+
+    <div x-show="latexResults.length > 0" class="import-results" x-cloak>
+      <h3>Resultado:</h3>
+      <ul>
+        <template x-for="r in latexResults" :key="r.id">
+          <li :class="{ ok: r.ok, err: !r.ok }">
+            <span x-text="r.ok ? '✓' : '✗'"></span>
+            <span x-text="r.id"></span>
+            <span x-show="r.action" class="path" x-text="'(' + r.action + ') → ' + r.path"></span>
+            <span x-show="r.error" class="error-msg" x-text="r.error"></span>
+          </li>
+        </template>
+      </ul>
+    </div>
+  </section>
+
+  <!-- LATEX PREVIEW MODAL -->
+  <div class="editor-overlay" x-show="latexPreview" @click.self="latexPreview = null" x-cloak>
+    <div class="editor-modal">
+      <div class="editor-header">
+        <h2 x-text="latexPreview ? ('📐 ' + latexPreview.parsed.title) : ''"></h2>
+        <div class="header-actions">
+          <button class="btn primary" @click="importOneLatex(latexPreview.id)">Importar esta</button>
+          <button class="btn" @click="latexPreview = null">✕ Cerrar</button>
+        </div>
+      </div>
+      <div class="editor-body" x-show="latexPreview">
+        <div class="editor-pane" style="overflow:auto">
+          <h4 style="margin:0 0 6px">.cho resultante</h4>
+          <pre class="latex-preview" x-text="latexPreview ? latexPreview.content : ''"></pre>
+        </div>
+        <div class="editor-pane" style="overflow:auto;border-left:1px solid var(--border)">
+          <h4 style="margin:0 0 6px">.tex original</h4>
+          <pre class="latex-preview" x-text="latexPreview ? latexPreview.latex_raw : ''"></pre>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- REORDENAR -->
   <section x-show="view === 'reorder' && data" x-cloak>

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -405,6 +405,23 @@
           <input type="text" x-model="editor.meta.artist" @input="updateMetaInRaw('artist', $event.target.value)" />
           <label>Tono (key)</label>
           <input type="text" x-model="editor.meta.key" @input="updateMetaInRaw('key', $event.target.value)" />
+          <div class="transpose-box">
+            <div class="transpose-row">
+              <button type="button" class="btn-mini transpose-btn" @click="transposeSong(-1)" title="Bajar medio tono (todos los acordes)">−½ tono</button>
+              <button type="button" class="btn-mini transpose-btn" @click="transposeSong(1)" title="Subir medio tono (todos los acordes)">+½ tono</button>
+            </div>
+            <div class="transpose-row">
+              <select class="transpose-select"
+                      @change="transposeSongToKey($event.target.value); $event.target.value=''"
+                      title="Transpone toda la canción al tono elegido y machaca el campo Tono">
+                <option value="">🎵 Llevar a tono…</option>
+                <template x-for="k in commonKeyOptions()" :key="k">
+                  <option :value="k" x-text="k"></option>
+                </template>
+              </select>
+            </div>
+            <div class="transpose-help">Mueve <strong>todos</strong> los acordes y sobrescribe el campo Tono. Pulsa 💾 para guardar el cambio definitivo.</div>
+          </div>
           <label>Capo</label>
           <input type="number" min="0" x-model="editor.meta.capo" @input="updateMetaInRaw('capo', $event.target.value)" />
           <div class="editor-status-selector">
@@ -422,13 +439,18 @@
             <small x-text="editor.path"></small>
           </div>
           <div class="meta-chuleta">
-            <div class="chuleta-title">Atajos rápidos</div>
-            <div class="chuleta-row"><span class="chuleta-key">○ margen</span> seleccionar línea</div>
-            <div class="chuleta-row"><span class="chuleta-key">Shift+click</span> rango</div>
-            <div class="chuleta-row"><span class="chuleta-key">📋 Copiar</span> guarda acordes <em>(limpia selección)</em></div>
-            <div class="chuleta-row"><span class="chuleta-key">📥 Pegar</span> aplica al destino</div>
-            <div class="chuleta-row"><span class="chuleta-key">Ctrl+S</span> guardar</div>
+            <div class="chuleta-title">Copiar acordes entre estrofas (paso a paso)</div>
+            <div class="chuleta-step"><span class="step-num">1</span> Click en el círculo <span class="chuleta-key">○</span> del margen izquierdo de cada línea con los acordes que quieres copiar (se pondrá <span class="chuleta-key chuleta-on">◉</span> azul).</div>
+            <div class="chuleta-step"><span class="step-num">2</span> Pulsa <span class="chuleta-key">📋 Copiar acordes</span> en la barra de arriba.</div>
+            <div class="chuleta-step"><span class="step-num">3</span> Marca ahora las líneas DESTINO con sus círculos.</div>
+            <div class="chuleta-step"><span class="step-num">4</span> Pulsa <span class="chuleta-key">📥 Pegar acordes</span>.</div>
+          </div>
+          <div class="meta-chuleta">
+            <div class="chuleta-title">Otros atajos</div>
+            <div class="chuleta-row"><span class="chuleta-key">Shift+click ○</span> selección de rango</div>
+            <div class="chuleta-row"><span class="chuleta-key">Ctrl+S</span> guardar canción</div>
             <div class="chuleta-row"><span class="chuleta-key">2×click acorde</span> editar texto</div>
+            <div class="chuleta-row"><span class="chuleta-key">2×click letra</span> editar letra</div>
             <div class="chuleta-row"><span class="chuleta-key">drag acorde</span> sílaba · Shift=palabra · Alt=libre</div>
           </div>
         </div>
@@ -468,6 +490,16 @@
 
           <div class="visual-add-hint" x-show="visualAddMode" x-cloak>
             🟢 Modo añadir activado — pincha sobre cualquier letra para insertar un acorde nuevo.
+          </div>
+
+          <div class="copypaste-banner"
+               x-show="visualChordClipboard || visualSelectedLines.size > 0"
+               :class="{ 'cp-ready': visualChordClipboard }"
+               x-cloak>
+            <span class="cp-text" x-text="copyPasteHint()"></span>
+            <span class="cp-info" x-show="clipboardInfo" x-text="clipboardInfo"></span>
+            <button class="link-mini" x-show="visualChordClipboard"
+                    @click="cancelChordClipboard()" title="Cancelar el patrón copiado">✕ cancelar copia</button>
           </div>
 
           <div class="visual-doc"

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -276,6 +276,35 @@ table.songs tr.selected-row td { background: rgba(37,99,235,0.07); }
 
 .visual-add-hint { background: rgba(22, 163, 74, 0.12); color: var(--ok); padding: 6px 10px; border-radius: 4px; font-size: 12px; margin-bottom: 6px; }
 
+.copypaste-banner {
+  background: rgba(37, 99, 235, 0.10); color: var(--accent);
+  border: 1px solid rgba(37, 99, 235, 0.30); border-radius: 6px;
+  padding: 8px 12px; font-size: 13px; margin-bottom: 8px;
+  display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+}
+.copypaste-banner.cp-ready { background: rgba(202, 138, 4, 0.12); color: var(--warn); border-color: rgba(202, 138, 4, 0.35); }
+.copypaste-banner .cp-text { flex: 1; min-width: 200px; font-weight: 500; }
+.copypaste-banner .cp-info { font-size: 11px; opacity: 0.85; background: rgba(0,0,0,0.06); padding: 2px 8px; border-radius: 3px; }
+.copypaste-banner .link-mini { background: transparent; border: 1px solid currentColor; color: inherit; padding: 2px 8px; border-radius: 3px; cursor: pointer; font-size: 11px; opacity: 0.75; }
+.copypaste-banner .link-mini:hover { opacity: 1; }
+
+.transpose-box {
+  margin-top: 6px; padding: 8px; background: var(--bg-3);
+  border-radius: 6px; border: 1px solid var(--border);
+}
+.transpose-row { display: flex; gap: 6px; margin-bottom: 6px; }
+.transpose-row:last-child { margin-bottom: 0; }
+.transpose-btn { flex: 1; font-weight: 600; font-size: 12px; padding: 5px 6px; }
+.transpose-select {
+  width: 100%; padding: 5px 6px; border: 1px solid var(--border-strong);
+  border-radius: 4px; background: var(--bg-2); color: var(--fg); font-size: 12px; cursor: pointer;
+}
+.transpose-help { font-size: 10px; color: var(--fg-3); margin-top: 6px; line-height: 1.3; }
+
+.chuleta-step { font-size: 11px; color: var(--fg-2); padding: 3px 0; line-height: 1.4; display: flex; gap: 6px; align-items: flex-start; }
+.chuleta-step .step-num { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; background: var(--accent); color: white; border-radius: 50%; font-size: 10px; font-weight: 700; flex-shrink: 0; margin-top: 1px; }
+.chuleta-key.chuleta-on { background: var(--accent); color: white; border-color: var(--accent); }
+
 .visual-doc {
   outline: none; padding: 16px; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px;
   /* Carlito = clon métrico de Calibri (mismas anchuras de caracteres).
@@ -314,10 +343,13 @@ table.songs tr.selected-row td { background: rgba(37,99,235,0.07); }
 .ed-line .line-gutter {
   position: absolute; left: 0; top: 0; width: 24px; height: 100%;
   display: flex; align-items: center; justify-content: center;
-  cursor: pointer; color: transparent; font-size: 12px; user-select: none;
+  cursor: pointer; color: var(--fg-3); opacity: 0.4;
+  font-size: 14px; user-select: none;
+  transition: opacity 0.12s, color 0.12s, transform 0.1s;
 }
-.ed-line:hover .line-gutter { color: var(--fg-3); }
-.ed-line.selected .line-gutter { color: var(--accent); }
+.ed-line.ed-lyric .line-gutter { opacity: 0.55; }
+.ed-line:hover .line-gutter { color: var(--accent); opacity: 1; transform: scale(1.15); }
+.ed-line.selected .line-gutter { color: var(--accent); opacity: 1; font-weight: bold; }
 .ed-line.selected .ed-lyric-row { background: rgba(37, 99, 235, 0.08); }
 .theme-dark .ed-line.selected .ed-lyric-row { background: rgba(59, 130, 246, 0.18); }
 .ed-line.ed-soc + .ed-line.ed-lyric .ed-line-row,

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -174,6 +174,41 @@ table.songs tr.selected-row td { background: rgba(37,99,235,0.07); }
 .stat.chord-review { border-left: 4px solid var(--info); }
 .warn-cell { font-size: 11px; color: var(--warn); }
 
+/* ─────── Importar LaTeX ─────── */
+table.songs tr.has-match td { background: rgba(139, 92, 246, 0.06); }
+.theme-dark table.songs tr.has-match td { background: rgba(139, 92, 246, 0.14); }
+.badge-latex {
+  display: inline-block; margin-left: 8px; padding: 1px 6px; font-size: 10px;
+  background: rgba(139, 92, 246, 0.18); color: #6d28d9; border-radius: 3px;
+  cursor: pointer; border: 1px solid rgba(139, 92, 246, 0.35);
+}
+.badge-latex:hover { background: rgba(139, 92, 246, 0.30); }
+.theme-dark .badge-latex { color: #c4b5fd; }
+.badge-overwrite {
+  display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
+  background: rgba(202, 138, 4, 0.18); color: var(--warn); border: 1px solid rgba(202, 138, 4, 0.4);
+  font-weight: 600;
+}
+.badge-new {
+  display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
+  background: rgba(22, 163, 74, 0.15); color: var(--ok); border: 1px solid rgba(22, 163, 74, 0.4);
+  font-weight: 600;
+}
+.repo-match { font-size: 12px; }
+.repo-match .match-num { display: inline-block; background: var(--accent); color: white; padding: 1px 6px; border-radius: 3px; font-weight: 700; font-size: 11px; margin-right: 4px; }
+.row-meta { font-size: 10px; color: var(--fg-3); margin-top: 2px; }
+.muted-mini { font-size: 11px; color: var(--fg-3); font-style: italic; }
+.mode-toggle { display: flex; flex-direction: column; gap: 3px; font-size: 11px; }
+.mode-toggle label { display: flex; gap: 4px; align-items: center; cursor: pointer; }
+.cat-select-mini { padding: 3px 6px; font-size: 11px; border: 1px solid var(--border-strong); border-radius: 3px; background: var(--bg-2); color: var(--fg); max-width: 140px; }
+.cat-select-mini:disabled { opacity: 0.45; cursor: not-allowed; }
+.latex-preview {
+  background: var(--bg-3); padding: 12px; border-radius: 4px;
+  font-family: "Carlito", "Calibri", monospace; font-size: 12px;
+  white-space: pre-wrap; word-break: break-word; line-height: 1.4;
+  max-height: 70vh; overflow: auto; margin: 0;
+}
+
 /* Status pills */
 .status-pill { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 10px; font-weight: 600; white-space: nowrap; }
 .status-pill.status-revisar { background: rgba(234,88,12,0.12); color: var(--todo); border: 1px solid rgba(234,88,12,0.25); }


### PR DESCRIPTION
## Summary
This PR adds a complete LaTeX import pipeline to the admin interface, allowing users to import songs from `.tex` files in `scripts/input/` directories. It also introduces chord transposition functionality for the visual editor.

## Key Changes

### LaTeX Import System
- **New module `latex_import.py`**: Handles scanning, parsing, and conversion of `.tex` files to ChordPro format
  - Reuses existing `tab2chordpro.py` logic with a silent translation mode (no console prompts)
  - Maps LaTeX folder names to song categories (entrada→A, gloria→B, etc.)
  - Detects unknown chords and reports them as warnings
  - Generates ChordPro output with metadata headers and "TO DO" markers for review

- **New API endpoints** (`/api/latex/list`, `/api/latex/preview`, `/api/latex/import`, `/api/latex/rescan`):
  - List all `.tex` files with metadata and repo matching
  - Preview converted ChordPro output before import
  - Import with two modes: create new song or overwrite existing (if title matches)
  - Auto-move processed files to `scripts/input/processed/`

- **UI for LaTeX import** (new "📐 Importar de LaTeX" tab):
  - Filter by folder, search by title/filename, filter by match status
  - Select import mode per song (overwrite vs. create new)
  - Override target category if needed
  - Display warnings for unknown chords
  - Show repo matches with visual indicators

### Chord Transposition
- **New transposition functions** in `app.js`:
  - `transposeSong(semis)`: Transpose all chords by N semitones
  - `transposeSongToKey(targetKey)`: Transpose to a specific key
  - `transposeChordText()`: Transpose individual chord symbols
  - Smart flat/sharp selection based on target key conventions

- **UI controls** in editor:
  - Transpose buttons (±1 semitone)
  - Dropdown to transpose to common keys
  - Updates metadata key field automatically
  - Shows count of transposed chords in status indicator

### Chord Copy/Paste Improvements
- **Persistent clipboard info**: `clipboardInfo` field displays copy status across operations
- **Better UX hints**: `copyPasteHint()` provides contextual guidance through the copy→paste workflow
- **Cancel clipboard**: New `cancelChordClipboard()` method to clear clipboard
- **Improved alerts**: More detailed instructions when selection is missing

### Dashboard & Catalog Integration
- Dashboard now shows LaTeX stats (new/total count)
- Catalog marks songs available in both DOCX and LaTeX
- Badge on DOCX import view links to LaTeX version (with note that LaTeX has better quality)
- Repo songs enriched with `in_latex`, `latex_id` fields

### Styling
- New CSS for LaTeX import UI: badges, mode toggles, category selectors
- Copy/paste banner with contextual styling
- Transpose controls styling
- Dark theme support for new elements

## Implementation Details
- LaTeX category mapping is configurable via `LATEX_CATEGORY_MAP` dict
- Unknown chords are collected silently (no prompts) and reported as warnings
- Title matching uses normalized keys (same logic as DOCX import)
- Transposition uses note index lookup with proper modulo arithmetic for wraparound
- Flat/sharp preference determined by target key conventions (e.g., F major prefers flats)
- Cache invalidation on rescan to ensure fresh file list

https://claude.ai/code/session_01XRBwxZNaFiHrafbMbJCKdY