### PR TITLE
Admin: importador desde doceacordes.es + multimedia en canciones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 acceso-firebase.json
 
+# Admin local
+.claude/
+scripts/cache_doceacordes/
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,30 @@ Una vez configurados, cualquier push a `main` crear\xC3\xA1 la nueva versi\xC3\x
 autom\xC3\xA1tica.
 
 El flujo solo se ejecuta cuando se env\xC3\xADan cambios a la carpeta `songs` en la rama `main`. Cuando esto ocurre se realizan las siguientes acciones:
+
+## Campos de canción en `songs-vX.json`
+
+Cada entrada de canción puede incluir, además de los clásicos
+(`title`, `filename`, `author`, `key`, `capo`, `content`), estos
+campos opcionales — emitidos sólo cuando existen — que provienen de
+*custom directives* MCM dentro del propio `.cho`:
+
+| Campo JSON       | Directive en `.cho`              | Tipo                       | Descripción |
+|------------------|----------------------------------|----------------------------|-------------|
+| `rhythm`         | `{ritmo: …}`                     | string                     | Patrón rítmico ("parones+rasgueo", "balada 6/8"…). |
+| `album`          | `{album: …}`                     | string                     | Álbum/disco donde aparece la versión de referencia. |
+| `liturgicalTime` | `{tiempo: …}`                    | string                     | Tiempo litúrgico y/o fiestas (separados por ` \| `). |
+| `source`         | `{fuente: …}`                    | string                     | Origen del chordpro (ej. `doceacordes.es - Parroquia San Bruno`). |
+| `videoEmbed`     | `{video: URL}`                   | string                     | URL embebible del vídeo principal. |
+| `youtubeLinks`   | `{youtube: Label \| URL}` (repetible) | `[{label, url}, …]`   | Lista ordenada de enlaces YouTube (orden = prioridad). |
+| `audioLinks`     | `{audio: Label \| URL}` (repetible)   | `[{label, url}, …]`   | Lista ordenada de grabaciones internas (Drive, mp3…). |
+| `comment`        | `{comentario: …}`                | string                     | Comentario libre (no se renderiza en el chordpro). |
+
+Estas directives **no se imprimen** en el cuerpo de la canción que ve
+el cantor: `scripts/crear_songs_json.py` las extrae a campos propios
+del JSON y las elimina del campo `content` antes de emitirlo.
+
+Edición desde el admin local: panel **🎬 Multimedia** del editor de
+canción + acción rápida (icono ➕📺 / ➕🎧) en el catálogo. Las
+canciones importadas con **🎸 Importar de doceacordes.es** rellenan
+estos campos automáticamente con un scraping de la página oficial.

--- a/scripts/admin/doceacordes_import.py
+++ b/scripts/admin/doceacordes_import.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Importador de canciones desde doceacordes.es → ChordPro estilo MCM.
+
+Descarga el ChordPro de https://doceacordes.es/cancion/{ID}/chordpro y lo
+adapta a nuestras convenciones:
+  - {start_of_chorus}/{end_of_chorus} → {soc}/{eoc}
+  - Acordes en español (Do, Re, Mi…) → inglés (C, D, E…)
+  - {key: Re} → {key: D}
+  - Prepend {comment: TO DO: PENDIENTE REVISIÓN ACORDES}
+  - Limpia espacios sobrantes dentro de los corchetes ([F ] → [F])
+
+Usa el JSON local scripts/canciones_doce_acordes.json como índice
+título/artista → ID. Permite matching difuso para sugerir candidatos.
+"""
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = SCRIPT_DIR.parent
+REPO_DIR = SCRIPTS_DIR.parent
+DOCE_INDEX_JSON = SCRIPTS_DIR / "canciones_doce_acordes.json"
+CACHE_DIR = SCRIPTS_DIR / "cache_doceacordes"
+
+TODO_COMMENT_LINE = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
+BASE_URL = "https://doceacordes.es"
+
+# ─────────── Traducción ES → EN de acordes ─────────── #
+
+# Notas: el orden importa, primero las largas para que regex matchee "Sol" antes que "So".
+ES_NOTE_MAP = {
+    "Do": "C", "Re": "D", "Mi": "E", "Fa": "F", "Sol": "G", "La": "A", "Si": "B",
+    "DO": "C", "RE": "D", "MI": "E", "FA": "F", "SOL": "G", "LA": "A", "SI": "B",
+    "do": "C", "re": "D", "mi": "E", "fa": "F", "sol": "G", "la": "A", "si": "B",
+}
+
+# Regex que captura una nota española al inicio de un token de acorde
+# Acepta variantes: Sol, La, Do# sostenido, Mib, Solm, Lam7, Re/Fa#…
+_NOTE_RE = re.compile(
+    r"\b(Sol|SOL|sol|Do|DO|do|Re|RE|re|Mi|MI|mi|Fa|FA|fa|La|LA|la|Si|SI|si)"
+    r"(?![a-rt-zA-RT-Z])"  # evita matchear "Sol" dentro de "Solo" pero permite "Solm"
+)
+
+
+def translate_chord_token(tok: str) -> str:
+    """Traduce un solo token de acorde español→inglés. Idempotente para acordes ya en EN."""
+    if not tok:
+        return tok
+    # Procesa "Do/Mi" → "C/E"
+    if "/" in tok:
+        parts = tok.split("/")
+        return "/".join(translate_chord_token(p) for p in parts)
+
+    # Buscar la nota española al inicio
+    m = re.match(
+        r"^(Sol|SOL|sol|Do|DO|do|Re|RE|re|Mi|MI|mi|Fa|FA|fa|La|LA|la|Si|SI|si)(.*)$",
+        tok,
+    )
+    if not m:
+        return tok
+    note_es, rest = m.group(1), m.group(2)
+    note_en = ES_NOTE_MAP.get(note_es, note_es)
+    # En español "m" minúscula = menor; en inglés también "m". OK pasa tal cual.
+    # "M" mayúscula a veces se usa para mayor, en inglés se omite.
+    if rest.startswith("M") and not rest.startswith("Maj") and not rest.startswith("m"):
+        rest = rest[1:]
+    return note_en + rest
+
+
+def translate_chord_in_brackets(content: str) -> str:
+    """Traduce todos los [Acorde] del cuerpo."""
+    def repl(m: re.Match) -> str:
+        inner = m.group(1).strip()  # limpia "[F ]" → "F"
+        if not inner:
+            return "[]"
+        return "[" + translate_chord_token(inner) + "]"
+    return re.sub(r"\[([^\]]+)\]", repl, content)
+
+
+def translate_key_value(key_es: str) -> str:
+    """Traduce el valor de {key: Re} → 'D'. Acepta ya en inglés."""
+    if not key_es:
+        return key_es
+    return translate_chord_token(key_es.strip())
+
+
+# ─────────── Adaptación del .cho completo ─────────── #
+
+def adapt_chordpro(raw: str) -> str:
+    """Toma el .cho crudo de doceacordes y lo deja estilo MCM."""
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+
+    # Compactar blancas: doceacordes mete 1 blanca entre cada línea y 2-3
+    # blancas como separador de estrofa. Convertimos 1 blanca → 0,
+    # 2+ blancas → 1 (separador de estrofa).
+    lines = text.split("\n")
+    out: List[str] = []
+    blank_run = 0
+    for ln in lines:
+        if ln.strip() == "":
+            blank_run += 1
+        else:
+            if out:
+                # Si veníamos de >= 2 blancas → separador de párrafo (1 blanca)
+                # Si veníamos de 1 blanca → era ruido (0 blancas)
+                if blank_run >= 2:
+                    out.append("")
+            out.append(ln)
+            blank_run = 0
+    text = "\n".join(out)
+
+    # Marcadores de estribillo
+    text = re.sub(r"\{\s*start_of_chorus\s*\}", "{soc}", text, flags=re.IGNORECASE)
+    text = re.sub(r"\{\s*end_of_chorus\s*\}", "{eoc}", text, flags=re.IGNORECASE)
+
+    # Traducir el valor de {key: ...}
+    def _key_repl(m: re.Match) -> str:
+        return "{key: " + translate_key_value(m.group(1)) + "}"
+    text = re.sub(r"\{\s*key\s*:\s*([^}]+)\}", _key_repl, text, flags=re.IGNORECASE)
+
+    # Traducir acordes dentro de [...]
+    text = translate_chord_in_brackets(text)
+
+    # Prepend TO DO si no está
+    if not re.search(r"\bTO\s+DO\b", text):
+        # Insertar como primera línea (antes de cualquier directive)
+        text = TODO_COMMENT_LINE + "\n" + text.lstrip("\n")
+
+    # Asegurar newline final
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def extract_meta_from_cho(content: str) -> Dict[str, str]:
+    """Extrae title/artist/key/capo de un .cho."""
+    def get(key: str) -> str:
+        m = re.search(r"\{\s*" + key + r"\s*:\s*(.*?)\s*\}", content, re.IGNORECASE)
+        return m.group(1).strip() if m else ""
+    return {
+        "title": get("title"),
+        "artist": get("artist"),
+        "key": get("key"),
+        "capo": get("capo"),
+    }
+
+
+# ─────────── Descarga ─────────── #
+
+def _cache_path(doce_id: str) -> Path:
+    CACHE_DIR.mkdir(exist_ok=True)
+    return CACHE_DIR / f"{doce_id}.cho"
+
+
+def _cache_html_path(doce_id: str) -> Path:
+    CACHE_DIR.mkdir(exist_ok=True)
+    return CACHE_DIR / f"{doce_id}.html"
+
+
+def fetch_chordpro(doce_id: str, use_cache: bool = True) -> str:
+    """Descarga (o lee de cache) el .cho crudo de una canción."""
+    doce_id = str(doce_id)
+    cache = _cache_path(doce_id)
+    if use_cache and cache.exists():
+        return cache.read_text(encoding="utf-8")
+    url = f"{BASE_URL}/cancion/{doce_id}/chordpro"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "mcmapp-cantoral admin/1.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+    cache.write_text(raw, encoding="utf-8")
+    return raw
+
+
+def fetch_html(doce_id: str, use_cache: bool = True) -> str:
+    """Descarga la página HTML de la canción (para extraer metadatos extra)."""
+    doce_id = str(doce_id)
+    cache = _cache_html_path(doce_id)
+    if use_cache and cache.exists():
+        return cache.read_text(encoding="utf-8")
+    url = f"{BASE_URL}/cancion/{doce_id}"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "mcmapp-cantoral admin/1.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+    cache.write_text(raw, encoding="utf-8")
+    return raw
+
+
+# ─────────── Scraping metadatos HTML ─────────── #
+
+def _strip_html(s: str) -> str:
+    """Elimina tags HTML y decodifica entidades básicas."""
+    if not s:
+        return ""
+    s = re.sub(r"<[^>]+>", " ", s)
+    s = (s.replace("&aacute;", "á").replace("&eacute;", "é").replace("&iacute;", "í")
+           .replace("&oacute;", "ó").replace("&uacute;", "ú").replace("&ntilde;", "ñ")
+           .replace("&Aacute;", "Á").replace("&Eacute;", "É").replace("&Iacute;", "Í")
+           .replace("&Oacute;", "Ó").replace("&Uacute;", "Ú").replace("&Ntilde;", "Ñ")
+           .replace("&amp;", "&").replace("&quot;", '"').replace("&#39;", "'")
+           .replace("&nbsp;", " "))
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def extract_metadata_from_html(html: str) -> Dict[str, object]:
+    """Extrae metadatos extra del HTML de doceacordes (sin BeautifulSoup).
+
+    Returns dict con: ritmo, parroquia, album, momento, tiempo_liturgico,
+    fiestas (list), comentario, video_embed, youtube_links (list of {label,url}).
+    """
+    meta: Dict[str, object] = {
+        "ritmo": "", "parroquia": "", "album": "", "momento": "",
+        "tiempo_liturgico": "", "fiestas": [], "comentario": "",
+        "video_embed": "", "youtube_links": [],
+    }
+
+    # Video embebido (primer iframe de youtube)
+    m = re.search(r'<iframe[^>]+src="([^"]*youtube[^"]*)"', html, re.IGNORECASE)
+    if m:
+        meta["video_embed"] = m.group(1)
+
+    # Links de YouTube (no embed) con su texto como etiqueta
+    for m in re.finditer(
+        r'<a[^>]+href="([^"]*youtube\.com/watch[^"]*)"[^>]*>(.*?)</a>',
+        html, re.IGNORECASE | re.DOTALL,
+    ):
+        url = m.group(1)
+        label = _strip_html(m.group(2)) or "YouTube"
+        meta["youtube_links"].append({"label": label, "url": url})
+
+    # Pares <b>Campo</b> [<br>] <i>Valor</i>  → "Álbum", "Momento", "Tiempo litúrgico", "Comentario"
+    for m in re.finditer(
+        r"<b[^>]*>([^<]+)</b>\s*(?:<br\s*/?>\s*)?<i[^>]*>(.*?)</i>",
+        html, re.IGNORECASE | re.DOTALL,
+    ):
+        k = _strip_html(m.group(1)).rstrip(":").lower()
+        v = _strip_html(m.group(2))
+        if not v:
+            continue
+        if k.startswith("álbum") or k.startswith("album"):
+            meta["album"] = v
+        elif k.startswith("momento"):
+            meta["momento"] = v
+        elif k.startswith("tiempo"):
+            meta["tiempo_liturgico"] = v
+        elif k.startswith("comentario"):
+            meta["comentario"] = v
+
+    # Fiestas: badges
+    for m in re.finditer(
+        r'class="[^"]*badge[^"]*"[^>]*>(.*?)</', html, re.IGNORECASE | re.DOTALL,
+    ):
+        v = _strip_html(m.group(1))
+        if v and v.lower() not in ("álbum", "momento", "tiempo litúrgico", "comentario"):
+            meta["fiestas"].append(v)
+
+    # Cejilla, Ritmo, Parroquia (en card-footer)
+    fm = re.search(r'class="[^"]*card-footer[^"]*"[^>]*>(.*?)</div>',
+                   html, re.IGNORECASE | re.DOTALL)
+    footer_text = _strip_html(fm.group(1)) if fm else ""
+    if not footer_text:
+        # Fallback: buscar palabras clave en todo el HTML
+        footer_text = _strip_html(html)
+    rm = re.search(r"Ritmo:\s*([^\n,]+?)(?:\s+(?:Parroquia|Cejilla)|$)",
+                   footer_text, re.IGNORECASE)
+    if rm:
+        meta["ritmo"] = rm.group(1).strip()
+    pm = re.search(r"Parroquia\s+([^\n]+?)(?:\s+(?:Ritmo|Cejilla)|$)",
+                   footer_text, re.IGNORECASE)
+    if pm:
+        meta["parroquia"] = pm.group(1).strip()
+
+    return meta
+
+
+def fetch_extra_meta(doce_id: str, use_cache: bool = True) -> Dict[str, object]:
+    """Descarga el HTML y extrae metadatos extra."""
+    html = fetch_html(doce_id, use_cache=use_cache)
+    return extract_metadata_from_html(html)
+
+
+def render_meta_directives(extra: Dict[str, object]) -> List[str]:
+    """Convierte el dict de metadatos extra en líneas de directives ChordPro."""
+    lines: List[str] = []
+    if extra.get("ritmo"):
+        lines.append(f"{{ritmo: {extra['ritmo']}}}")
+    if extra.get("album"):
+        lines.append(f"{{album: {extra['album']}}}")
+    # tiempo litúrgico + fiestas fusionados con " | "
+    tiempos = []
+    if extra.get("tiempo_liturgico"):
+        tiempos.append(extra["tiempo_liturgico"])
+    fiestas = extra.get("fiestas") or []
+    for f in fiestas:
+        if f not in tiempos:
+            tiempos.append(f)
+    if tiempos:
+        lines.append(f"{{tiempo: {' | '.join(tiempos)}}}")
+    if extra.get("momento"):
+        # momento va como otro tiempo, separado: lo unimos al campo tiempo
+        # (se podría sacar a campo propio, pero lo mantenemos en tiempo)
+        if not any("tiempo:" in ln for ln in lines):
+            lines.append(f"{{tiempo: {extra['momento']}}}")
+        else:
+            lines[-1] = lines[-1][:-1] + f" | {extra['momento']}" + "}"
+    fuente_parts = ["doceacordes.es"]
+    if extra.get("parroquia"):
+        fuente_parts.append(f"Parroquia {extra['parroquia']}")
+    lines.append(f"{{fuente: {' - '.join(fuente_parts)}}}")
+    if extra.get("video_embed"):
+        lines.append(f"{{video: {extra['video_embed']}}}")
+    for yt in (extra.get("youtube_links") or []):
+        label = yt.get("label") or "YouTube"
+        url = yt.get("url") or ""
+        if url:
+            lines.append(f"{{youtube: {label} | {url}}}")
+    if extra.get("comentario"):
+        lines.append(f"{{comentario: {extra['comentario']}}}")
+    return lines
+
+
+# ─────────── Índice título/artista → ID ─────────── #
+
+def _normalize(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s or "")
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    s = s.lower()
+    s = re.sub(r"\([^)]*\)", " ", s)
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    return s.strip()
+
+
+def _tokens(s: str) -> set:
+    return {t for t in _normalize(s).split() if t and len(t) > 1}
+
+
+def load_doce_index() -> List[dict]:
+    """Devuelve la lista completa del JSON con campo extra `_norm_title`/`_norm_artist`."""
+    if not DOCE_INDEX_JSON.exists():
+        return []
+    data = json.loads(DOCE_INDEX_JSON.read_text(encoding="utf-8"))
+    for entry in data:
+        entry["_norm_title"] = _normalize(entry.get("title", ""))
+        entry["_norm_artist"] = _normalize(entry.get("artist", ""))
+        entry["_tok_title"] = _tokens(entry.get("title", ""))
+    return data
+
+
+_doce_cache: Dict[str, object] = {"items": None}
+
+
+def doce_items() -> List[dict]:
+    if _doce_cache["items"] is None:
+        _doce_cache["items"] = load_doce_index()
+    return _doce_cache["items"]  # type: ignore
+
+
+def find_candidates(title: str, artist: str = "", top: int = 3) -> List[dict]:
+    """Devuelve top-N candidatos del JSON con un score de similitud por tokens.
+
+    Devuelve dicts con todos los campos del entry + `_score`.
+    """
+    norm_t = _normalize(title)
+    toks_t = _tokens(title)
+    if not toks_t:
+        return []
+    norm_a = _normalize(artist)
+    out: List[Tuple[float, dict]] = []
+    for entry in doce_items():
+        # Exact normalized match
+        if entry["_norm_title"] == norm_t:
+            score = 100.0
+        else:
+            inter = toks_t & entry["_tok_title"]
+            if not inter:
+                continue
+            # Jaccard scaled to 0-100
+            union = toks_t | entry["_tok_title"]
+            score = 100.0 * len(inter) / len(union)
+        # Boost si artista coincide aunque sea parcial
+        if norm_a and entry["_norm_artist"]:
+            artist_toks_in = _tokens(artist) & _tokens(entry["artist"])
+            if artist_toks_in:
+                score += 15.0
+        # Penaliza si tamaños muy distintos
+        size_ratio = min(len(toks_t), len(entry["_tok_title"])) / max(len(toks_t), len(entry["_tok_title"]))
+        score *= 0.5 + 0.5 * size_ratio
+        # Umbral mínimo
+        if score < 30:
+            continue
+        out.append((score, entry))
+    out.sort(key=lambda x: -x[0])
+    result = []
+    for score, entry in out[:top]:
+        e = {k: v for k, v in entry.items() if not k.startswith("_")}
+        e["_score"] = round(score, 1)
+        result.append(e)
+    return result
+
+
+def find_best_id(title: str, artist: str = "") -> Optional[str]:
+    cands = find_candidates(title, artist, top=1)
+    if not cands:
+        return None
+    # Sólo considerar match "fiable" si score alto
+    if cands[0]["_score"] < 70:
+        return None
+    return cands[0]["id"]
+
+
+def get_entry(doce_id: str) -> Optional[dict]:
+    doce_id = str(doce_id)
+    for entry in doce_items():
+        if str(entry.get("id")) == doce_id:
+            return {k: v for k, v in entry.items() if not k.startswith("_")}
+    return None
+
+
+# ─────────── Render final ─────────── #
+
+def fetch_and_adapt(doce_id: str, use_cache: bool = True,
+                    include_meta: bool = True) -> Tuple[str, Dict[str, str]]:
+    """Descarga el .cho, lo adapta y devuelve (contenido, meta).
+
+    Si include_meta=True, además descarga el HTML, extrae los metadatos extra
+    (ritmo, album, video, youtube_links, etc.) y los inserta como custom
+    directives en el header del .cho resultante.
+    """
+    raw = fetch_chordpro(doce_id, use_cache=use_cache)
+    adapted = adapt_chordpro(raw)
+    if include_meta:
+        try:
+            extra = fetch_extra_meta(doce_id, use_cache=use_cache)
+            meta_lines = render_meta_directives(extra)
+            if meta_lines:
+                adapted = inject_meta_lines(adapted, meta_lines)
+        except Exception:
+            # Si el scraping falla, devolvemos el .cho sin meta extra
+            pass
+    meta = extract_meta_from_cho(adapted)
+    return adapted, meta
+
+
+def inject_meta_lines(content: str, meta_lines: List[str]) -> str:
+    """Inserta las líneas de metadatos en el header, justo tras {capo}/{key}."""
+    if not meta_lines:
+        return content
+    # Normalizar blancas: el chordpro de doceacordes mete líneas en blanco entre
+    # cada directive del header. Compactamos el header antes de insertar.
+    lines = content.split("\n")
+    # 1) Filtrar repeticiones de meta-directives previas (idempotente)
+    meta_keys_new = {ln.split(":", 1)[0].strip("{ ").lower() for ln in meta_lines}
+    repeatable = {"youtube", "audio"}
+    filtered: List[str] = []
+    for ln in lines:
+        m = re.match(r"\s*\{\s*([a-zA-Z_]+)\s*:", ln)
+        if m and m.group(1).lower() in meta_keys_new:
+            if m.group(1).lower() in repeatable:
+                continue
+            continue
+        filtered.append(ln)
+    # 2) Encontrar el final del bloque "header": secuencia inicial de directives
+    #    permitiendo blancas intercaladas. Termina al ver una línea NO-blanca
+    #    y NO-directive.
+    insert_at = 0
+    seen_directive = False
+    for i, ln in enumerate(filtered):
+        if re.match(r"\s*\{[a-zA-Z_]+\s*:", ln):
+            insert_at = i + 1
+            seen_directive = True
+        elif ln.strip() == "":
+            # blanca: la incluimos en el header sólo si ya vimos alguna directive
+            if seen_directive:
+                continue
+            break
+        else:
+            break
+    new_lines = filtered[:insert_at] + meta_lines + filtered[insert_at:]
+    return "\n".join(new_lines)

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -306,17 +306,52 @@ def load_docx_songs(force: bool = False) -> List[dict]:
     paras = d2c.load_paragraphs(docx_path)
     raw_songs = d2c.split_into_songs(paras)
     indexed = []
+    # Contador por sección para asignar position_in_section (1-based) — usado
+    # como sugerencia de número de archivo al importar.
+    pos_by_section: Dict[str, int] = {}
     for i, s in enumerate(raw_songs):
+        letter = d2c.section_letter(s["section"])
+        pos_by_section[letter or ""] = pos_by_section.get(letter or "", 0) + 1
         indexed.append({
             "id": i,
             "title_raw": s["title_raw"],
             "section": s["section"],
-            "section_letter": d2c.section_letter(s["section"]),
+            "section_letter": letter,
+            "position_in_section": pos_by_section[letter or ""],
             "_song": s,
         })
     _docx_cache["songs"] = indexed
     _docx_cache["mtime"] = mtime
     return indexed
+
+
+def first_free_number(folder: Path, start: int = 1) -> int:
+    """Devuelve el primer número de slot libre en la carpeta (busca huecos)."""
+    used = set()
+    if folder.exists():
+        for f in folder.iterdir():
+            m = re.match(r"(\d+)\.", f.name)
+            if m:
+                try:
+                    used.add(int(m.group(1)))
+                except ValueError:
+                    pass
+    n = start
+    while n in used:
+        n += 1
+    return n
+
+
+def preferred_number(folder: Path, hint: Optional[int] = None) -> int:
+    """Si el número 'hint' está libre, lo usa. Si no, primer hueco libre desde 1."""
+    if isinstance(hint, int) and hint > 0:
+        if not folder.exists():
+            return hint
+        used = {int(m.group(1)) for f in folder.iterdir()
+                if (m := re.match(r"(\d+)\.", f.name))}
+        if hint not in used:
+            return hint
+    return first_free_number(folder)
 
 
 def docx_song_to_dict(s: dict, conv: dict, include_body: bool = False) -> dict:
@@ -326,6 +361,7 @@ def docx_song_to_dict(s: dict, conv: dict, include_body: bool = False) -> dict:
         "title": conv["title"],
         "section": s["section"],
         "section_letter": s["section_letter"],
+        "position_in_section": s.get("position_in_section"),
         "key": conv.get("key"),
         "capo": conv.get("capo"),
         "warnings": conv.get("warnings", []),
@@ -499,13 +535,14 @@ def api_catalog():
             "title": conv["title"],
             "title_raw": s["title_raw"],
             "section_letter": s["section_letter"],
+            "position_in_section": s.get("position_in_section"),
             "key": conv.get("key"),
             "capo": conv.get("capo"),
             "warnings": conv.get("warnings", []),
             "latex_available": bool(latex_alt),
             "latex_id": latex_alt["id"] if latex_alt else None,
             "doce_available": bool(doce_cands),
-            "doce_candidates": doce_cands,  # [{id,title,artist,subtitle,url,_score}, ...]
+            "doce_candidates": doce_cands,
         })
 
     # Contadores
@@ -823,7 +860,9 @@ def api_docx_import():
         if folder is None:
             results.append({"id": i, "ok": False, "error": "sin carpeta destino"})
             continue
-        num = d2c.next_song_number(folder)
+        # Sugerencia de número: posición de la canción dentro de su sección
+        # en el DOCX. Si está libre se respeta; si no, primer hueco libre.
+        num = preferred_number(folder, s.get("position_in_section"))
         fname = f"{num:02d}.{conv['slug']}.cho"
         fpath = folder / fname
         if fpath.exists():
@@ -1070,10 +1109,12 @@ def api_doce_preview():
     suggested_slug = d2c.slugify(d2c.pretty_title_case(meta.get("title") or entry.get("title", "")))
     suggested_number = None
     cat_letter = request.args.get("category", "").upper().strip()
+    hint_raw = request.args.get("position_hint", "").strip()
+    hint = int(hint_raw) if hint_raw.isdigit() else None
     if cat_letter:
         cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
         if cat:
-            suggested_number = d2c.next_song_number(SONGS_DIR / cat["folder"])
+            suggested_number = preferred_number(SONGS_DIR / cat["folder"], hint)
     extras = parse_extra_meta(content)
     return jsonify({
         "id": doce_id,
@@ -1088,13 +1129,15 @@ def api_doce_preview():
 
 @app.route("/api/doce/suggest-number")
 def api_doce_suggest_number():
-    """Devuelve el siguiente número libre en una categoría dada."""
+    """Devuelve un número sugerido (primer hueco libre, o el hint si está libre)."""
     cat_letter = request.args.get("category", "").upper().strip()
     cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
     if not cat:
         abort(404, "Categoría no encontrada")
     folder = SONGS_DIR / cat["folder"]
-    return jsonify({"category": cat_letter, "next_number": d2c.next_song_number(folder)})
+    hint_raw = request.args.get("position_hint", "").strip()
+    hint = int(hint_raw) if hint_raw.isdigit() else None
+    return jsonify({"category": cat_letter, "next_number": preferred_number(folder, hint)})
 
 
 @app.route("/api/doce/import", methods=["POST"])
@@ -1134,7 +1177,9 @@ def api_doce_import():
 
             num = it.get("number")
             if not (isinstance(num, int) and num > 0):
-                num = d2c.next_song_number(folder)
+                hint = it.get("position_hint")
+                hint_int = hint if (isinstance(hint, int) and hint > 0) else None
+                num = preferred_number(folder, hint_int)
             fname = f"{num:02d}.{slug}.cho"
             fpath = folder / fname
             if fpath.exists():
@@ -1154,8 +1199,43 @@ def api_doce_import():
 # ─────────── API: reordenar y build-json ─────────── #
 
 
+@app.route("/api/category/slots")
+def api_category_slots():
+    """Devuelve la representación 'con huecos' de una categoría: lista de
+    `{number, filename}` donde filename es null en los slots vacíos."""
+    letter = request.args.get("category", "").upper().strip()
+    cat = next((c for c in list_categories() if c["letter"] == letter), None)
+    if not cat:
+        abort(404, "Categoría no encontrada")
+    folder = SONGS_DIR / cat["folder"]
+    by_num: Dict[int, str] = {}
+    unnumbered: List[str] = []
+    for p in sorted(folder.glob("*.cho")):
+        m = re.match(r"(\d+)\.", p.name)
+        if m:
+            by_num[int(m.group(1))] = p.name
+        else:
+            unnumbered.append(p.name)
+    slots: List[dict] = []
+    if by_num:
+        max_num = max(by_num)
+        for n in range(1, max_num + 1):
+            slots.append({"number": n, "filename": by_num.get(n)})
+    # Sin numerar al final
+    for fn in unnumbered:
+        slots.append({"number": None, "filename": fn})
+    return jsonify({"category": letter, "slots": slots})
+
+
 @app.route("/api/reorder", methods=["POST"])
 def api_reorder():
+    """Reordena una categoría aceptando huecos.
+
+    Body: {category: "A", order: [<filename> | null, ...]}
+      - Cada índice i (1-based) es el número que tendrá esa canción.
+      - `null` = slot vacío (no se asigna ningún archivo a ese número).
+      - Compatible con el formato antiguo `order: [filename, ...]` (sin nulls).
+    """
     body = request.get_json(silent=True) or {}
     letter = body.get("category", "").upper()
     order = body.get("order", [])
@@ -1166,38 +1246,53 @@ def api_reorder():
         abort(404, "Categoría no encontrada")
     folder = SONGS_DIR / cat["folder"]
     current = {p.name: p for p in folder.glob("*.cho")}
-    # Validar que todos los filenames existen
-    for fn in order:
-        if fn not in current:
-            abort(400, f"Archivo no existe: {fn}")
-    # Hacer backup de la categoría completa
+    # Validar: todos los filenames no-null deben existir y ser únicos
+    seen = set()
+    for item in order:
+        if item is None:
+            continue
+        if not isinstance(item, str):
+            abort(400, f"Item inválido: {item!r}")
+        if item not in current:
+            abort(400, f"Archivo no existe: {item}")
+        if item in seen:
+            abort(400, f"Archivo duplicado en order: {item}")
+        seen.add(item)
+    # Crítico: el order debe cubrir TODOS los .cho de la carpeta, si no
+    # quedarían archivos con número duplicado tras el rename.
+    missing = set(current.keys()) - seen
+    if missing:
+        abort(400, f"Faltan archivos en order: {sorted(missing)}")
+    # Quitar trailing nulls (huecos al final no tienen sentido)
+    while order and order[-1] is None:
+        order.pop()
+    if not order:
+        abort(400, "order vacío")
+    # Backup
     ts = datetime.now().strftime("%Y%m%d-%H%M%S")
     backup_folder = BACKUP_DIR / ts / cat["folder"]
     backup_folder.mkdir(parents=True, exist_ok=True)
     for p in folder.glob("*.cho"):
         shutil.copy2(p, backup_folder / p.name)
-    # Renombrar: paso intermedio con prefijo temporal para evitar colisiones
+    # Paso 1: mover todo a temporales
     tmp_prefix = f".reorder-{int(time.time())}-"
-    intermediate: List[tuple[Path, str]] = []
-    for fn in order:
+    temp_pairs: List[tuple] = []  # (slot_number, tmp_path, base_name)
+    for idx, fn in enumerate(order, start=1):
+        if fn is None:
+            continue
         p = folder / fn
-        # Quitar prefijo numérico viejo si existe
         base = re.sub(r"^\d+\.", "", fn)
-        intermediate.append((p, base))
-    # Renombrar a temporales
-    temp_paths: List[tuple[Path, str]] = []
-    for p, base in intermediate:
-        tp = folder / (tmp_prefix + base)
+        tp = folder / (tmp_prefix + str(idx) + "-" + base)
         p.rename(tp)
-        temp_paths.append((tp, base))
-    # Renombrar a finales con números
-    final_paths = []
-    for idx, (tp, base) in enumerate(temp_paths, start=1):
-        final_name = f"{idx:02d}.{base}"
-        final = folder / final_name
-        tp.rename(final)
-        final_paths.append(final.name)
-    return jsonify({"ok": True, "category": letter, "new_order": final_paths})
+        temp_pairs.append((idx, tp, base))
+    # Paso 2: renombrar al número final
+    final_names: List[Optional[str]] = [None] * len(order)
+    for slot, tp, base in temp_pairs:
+        final_name = f"{slot:02d}.{base}"
+        (folder / final_name).exists()  # no debería existir; backup ya hecho
+        tp.rename(folder / final_name)
+        final_names[slot - 1] = final_name
+    return jsonify({"ok": True, "category": letter, "new_order": final_names})
 
 
 @app.route("/api/build-json", methods=["POST"])

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -46,6 +46,7 @@ IGNORED_FILE = SCRIPT_DIR / "import-ignored.json"
 sys.path.insert(0, str(SCRIPTS_DIR))
 import docx2chordpro as d2c  # noqa: E402
 import latex_import as lx  # noqa: E402
+import doceacordes_import as da  # noqa: E402
 
 # Marca para canciones pendientes de revisar acordes (TO DO con espacio entre TO y DO)
 TODO_COMMENT_LINE = "{comment: TO DO: PENDIENTE REVISIÓN ACORDES}"
@@ -70,13 +71,46 @@ def safe_relpath(path_str: str) -> Path:
     return p
 
 
-def parse_cho_metadata(content: str) -> Dict[str, str]:
-    """Extrae metadata básica de un .cho."""
+def _parse_label_url(value: str) -> Dict[str, str]:
+    if "|" in value:
+        label, _, url = value.partition("|")
+        return {"label": label.strip(), "url": url.strip()}
+    return {"label": "", "url": value.strip()}
+
+
+def parse_extra_meta(content: str) -> Dict[str, object]:
+    """Extrae las custom directives multimedia/meta MCM."""
+    extra: Dict[str, object] = {
+        "rhythm": "", "album": "", "liturgicalTime": "", "source": "",
+        "videoEmbed": "", "youtubeLinks": [], "audioLinks": [], "comment": "",
+    }
+    for m in re.finditer(
+        r"\{\s*(ritmo|album|tiempo|fuente|video|youtube|audio|comentario)\s*:\s*(.*?)\s*\}",
+        content, re.IGNORECASE,
+    ):
+        k = m.group(1).lower()
+        v = m.group(2).strip()
+        if not v:
+            continue
+        if k == "ritmo":         extra["rhythm"] = v
+        elif k == "album":       extra["album"] = v
+        elif k == "tiempo":      extra["liturgicalTime"] = v
+        elif k == "fuente":      extra["source"] = v
+        elif k == "video":       extra["videoEmbed"] = v
+        elif k == "comentario":  extra["comment"] = v
+        elif k == "youtube":     extra["youtubeLinks"].append(_parse_label_url(v))
+        elif k == "audio":       extra["audioLinks"].append(_parse_label_url(v))
+    return extra
+
+
+def parse_cho_metadata(content: str) -> Dict[str, object]:
+    """Extrae metadata básica + flags multimedia de un .cho."""
     def get(key: str) -> str:
         m = re.search(r"\{\s*" + key + r"\s*:\s*(.*?)\s*\}", content, re.IGNORECASE)
         return m.group(1).strip() if m else ""
 
     capo_raw = get("capo")
+    extra = parse_extra_meta(content)
     return {
         "title": get("title"),
         "artist": get("artist") or get("author"),
@@ -84,6 +118,17 @@ def parse_cho_metadata(content: str) -> Dict[str, str]:
         "capo": int(capo_raw) if capo_raw.isdigit() else 0,
         "has_todo": bool(TODO_REGEX.search(content)),
         "has_chord_review": bool(CHORD_REVIEW_REGEX.search(content)),
+        "has_video": bool(extra["videoEmbed"]),
+        "youtube_count": len(extra["youtubeLinks"]),
+        "audio_count": len(extra["audioLinks"]),
+        "rhythm": extra["rhythm"],
+        "album": extra["album"],
+        "liturgicalTime": extra["liturgicalTime"],
+        "source": extra["source"],
+        "videoEmbed": extra["videoEmbed"],
+        "youtubeLinks": extra["youtubeLinks"],
+        "audioLinks": extra["audioLinks"],
+        "comment": extra["comment"],
     }
 
 
@@ -196,6 +241,11 @@ def list_repo_songs(category_letter: Optional[str] = None) -> List[dict]:
                 "capo": meta.get("capo", 0),
                 "has_todo": meta.get("has_todo", False),
                 "has_chord_review": meta.get("has_chord_review", False),
+                "has_video": meta.get("has_video", False),
+                "youtube_count": meta.get("youtube_count", 0),
+                "audio_count": meta.get("audio_count", 0),
+                "rhythm": meta.get("rhythm", ""),
+                "album": meta.get("album", ""),
                 "error": meta_err,
             })
     return out
@@ -401,6 +451,7 @@ def api_catalog():
     # Marcar repo_songs con si está en docx y/o en LaTeX
     matched_docx_ids: set = set()
     matched_latex_ids: set = set()
+    matched_doce_ids: set = set()
     for r in repo_songs:
         match = best_match(title_keys(r["title"]), docx_index)
         if match:
@@ -419,6 +470,15 @@ def api_catalog():
         else:
             r["in_latex"] = False
             r["latex_id"] = None
+        # doceacordes (sólo el mejor match, alto score)
+        doce_id = da.find_best_id(r["title"], r.get("artist", ""))
+        if doce_id:
+            r["in_doce"] = True
+            r["doce_id"] = doce_id
+            matched_doce_ids.add(doce_id)
+        else:
+            r["in_doce"] = False
+            r["doce_id"] = None
 
     # Canciones del docx que NO están en repo (excluidas las archivadas)
     ignored = load_ignored()
@@ -432,6 +492,8 @@ def api_catalog():
         # ¿Está disponible esta misma canción en LaTeX? Si sí, avisamos y damos
         # prioridad a la versión LaTeX (el usuario debería importar de LaTeX, no de docx).
         latex_alt = best_match(title_keys(conv["title"]), latex_index)
+        # Candidatos doceacordes (top 3 difuso)
+        doce_cands = da.find_candidates(conv["title"], top=3)
         missing.append({
             "docx_id": s["id"],
             "title": conv["title"],
@@ -442,6 +504,8 @@ def api_catalog():
             "warnings": conv.get("warnings", []),
             "latex_available": bool(latex_alt),
             "latex_id": latex_alt["id"] if latex_alt else None,
+            "doce_available": bool(doce_cands),
+            "doce_candidates": doce_cands,  # [{id,title,artist,subtitle,url,_score}, ...]
         })
 
     # Contadores
@@ -449,6 +513,8 @@ def api_catalog():
     chord_review_count = sum(1 for r in repo_songs if r["has_chord_review"])
     latex_total = len(latex_items)
     latex_only_new = sum(1 for lt in latex_items if lt["id"] not in matched_latex_ids)
+    with_youtube = sum(1 for r in repo_songs if r.get("youtube_count", 0) > 0 or r.get("has_video"))
+    with_audio = sum(1 for r in repo_songs if r.get("audio_count", 0) > 0)
 
     return jsonify({
         "categories": list_categories(),
@@ -464,6 +530,10 @@ def api_catalog():
             "latex_total": latex_total,
             "latex_new": latex_only_new,
             "latex_matches_repo": len(matched_latex_ids),
+            "with_youtube": with_youtube,
+            "with_audio": with_audio,
+            "without_youtube": len(repo_songs) - with_youtube,
+            "without_audio": len(repo_songs) - with_audio,
         },
     })
 
@@ -505,6 +575,133 @@ def api_song_put():
     p.write_text(content, encoding="utf-8")
     meta = parse_cho_metadata(content)
     return jsonify({"ok": True, "path": str(p.relative_to(REPO_DIR)), "meta": meta})
+
+
+def _sanitize_directive_value(s: str) -> str:
+    """Limpia caracteres que romperían el parseo del .cho.
+    '}' cierra la directive; lo reemplaza por ')'.
+    '\\n' la divide en varias líneas; lo aplana a espacio.
+    """
+    if not s:
+        return ""
+    return str(s).replace("}", ")").replace("\n", " ").replace("\r", " ").strip()
+
+
+def _sanitize_link_label(s: str) -> str:
+    """Para labels: además del cleanup base, quitar '|' que es nuestro separador."""
+    return _sanitize_directive_value(s).replace("|", "/").strip()
+
+
+def _render_meta_directive_lines(meta: Dict[str, object]) -> List[str]:
+    """Genera las líneas de custom directives a partir de un dict de meta."""
+    lines: List[str] = []
+    if meta.get("rhythm"):
+        lines.append(f"{{ritmo: {_sanitize_directive_value(meta['rhythm'])}}}")
+    if meta.get("album"):
+        lines.append(f"{{album: {_sanitize_directive_value(meta['album'])}}}")
+    if meta.get("liturgicalTime"):
+        lines.append(f"{{tiempo: {_sanitize_directive_value(meta['liturgicalTime'])}}}")
+    if meta.get("source"):
+        lines.append(f"{{fuente: {_sanitize_directive_value(meta['source'])}}}")
+    if meta.get("videoEmbed"):
+        lines.append(f"{{video: {_sanitize_directive_value(meta['videoEmbed'])}}}")
+    for yt in (meta.get("youtubeLinks") or []):
+        label = _sanitize_link_label(yt.get("label") or "")
+        url = _sanitize_directive_value(yt.get("url") or "")
+        if not url:
+            continue
+        lines.append(f"{{youtube: {label} | {url}}}" if label else f"{{youtube: {url}}}")
+    for au in (meta.get("audioLinks") or []):
+        label = _sanitize_link_label(au.get("label") or "")
+        url = _sanitize_directive_value(au.get("url") or "")
+        if not url:
+            continue
+        lines.append(f"{{audio: {label} | {url}}}" if label else f"{{audio: {url}}}")
+    if meta.get("comment"):
+        lines.append(f"{{comentario: {_sanitize_directive_value(meta['comment'])}}}")
+    return lines
+
+
+_META_DIRECTIVE_RE = re.compile(
+    r"^[ \t]*\{\s*(ritmo|album|tiempo|fuente|video|youtube|audio|comentario)\s*:[^}]*\}[ \t]*\r?\n?",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _replace_meta_block(content: str, new_lines: List[str]) -> str:
+    """Borra todas las custom-meta directives existentes e inserta las nuevas
+    justo después del último directive de cabecera (title/artist/key/capo/comment)."""
+    stripped = _META_DIRECTIVE_RE.sub("", content)
+    if not new_lines:
+        return stripped
+    lines = stripped.split("\n")
+    insert_at = 0
+    for i, ln in enumerate(lines):
+        if re.match(r"\s*\{\s*(title|artist|author|key|capo|comment)\s*:", ln, re.IGNORECASE):
+            insert_at = i + 1
+        elif ln.strip() == "":
+            break
+        else:
+            break
+    new = lines[:insert_at] + new_lines + lines[insert_at:]
+    return "\n".join(new)
+
+
+@app.route("/api/song/meta", methods=["PUT"])
+def api_song_meta_put():
+    """Actualiza SOLO las custom directives multimedia/meta del .cho.
+
+    Body: {rhythm, album, liturgicalTime, source, videoEmbed,
+           youtubeLinks: [{label, url}], audioLinks: [{label, url}], comment}
+    """
+    path_str = request.args.get("path", "")
+    if not path_str:
+        abort(400, "Falta 'path'")
+    p = safe_relpath(path_str)
+    if not p.exists():
+        abort(404, "No existe")
+    body = request.get_json(silent=True) or {}
+    new_lines = _render_meta_directive_lines(body)
+    original = p.read_text(encoding="utf-8")
+    new_content = _replace_meta_block(original, new_lines)
+    if new_content == original:
+        return jsonify({"ok": True, "path": str(p.relative_to(REPO_DIR)),
+                        "meta": parse_cho_metadata(new_content), "unchanged": True})
+    backup_file(p)
+    p.write_text(new_content, encoding="utf-8")
+    return jsonify({"ok": True, "path": str(p.relative_to(REPO_DIR)),
+                    "meta": parse_cho_metadata(new_content)})
+
+
+@app.route("/api/song/meta/quick-add", methods=["POST"])
+def api_song_meta_quick_add():
+    """Atajo: añade UN link (youtube o audio) sin tener que mandar todo el meta.
+
+    Body: {path, type: 'youtube'|'audio', label, url, prepend?: bool}
+    """
+    body = request.get_json(silent=True) or {}
+    path_str = body.get("path", "")
+    link_type = (body.get("type") or "").lower()
+    label = (body.get("label") or "").strip()
+    url = (body.get("url") or "").strip()
+    if not path_str or link_type not in ("youtube", "audio") or not url:
+        abort(400, "Faltan campos (path, type=youtube|audio, url)")
+    p = safe_relpath(path_str)
+    if not p.exists():
+        abort(404, "No existe")
+    content = p.read_text(encoding="utf-8")
+    meta = parse_cho_metadata(content)
+    key = "youtubeLinks" if link_type == "youtube" else "audioLinks"
+    entry = {"label": label, "url": url}
+    if body.get("prepend"):
+        meta[key] = [entry] + list(meta.get(key) or [])
+    else:
+        meta[key] = list(meta.get(key) or []) + [entry]
+    new_lines = _render_meta_directive_lines(meta)
+    new_content = _replace_meta_block(content, new_lines)
+    backup_file(p)
+    p.write_text(new_content, encoding="utf-8")
+    return jsonify({"ok": True, "meta": parse_cho_metadata(new_content)})
 
 
 @app.route("/api/song/new", methods=["POST"])
@@ -823,6 +1020,135 @@ def api_songs_bulk_status():
         except Exception as e:
             results.append({"path": path_str, "ok": False, "error": str(e)})
     return jsonify({"ok": True, "results": results})
+
+
+# ─────────── API: doceacordes.es ─────────── #
+
+
+@app.route("/api/doce/list")
+def api_doce_list():
+    """Lista todas las canciones del índice JSON, enriquecidas con match en repo."""
+    items = da.doce_items()
+    repo_songs = list_repo_songs()
+    # Índice repo por título normalizado para detectar duplicados rápido
+    repo_by_norm: Dict[str, dict] = {}
+    for r in repo_songs:
+        for k in title_keys(r["title"]):
+            repo_by_norm.setdefault(k, r)
+
+    out = []
+    for entry in items:
+        r = best_match(title_keys(entry["title"]), repo_by_norm)
+        out.append({
+            "id": entry["id"],
+            "title": entry.get("title", ""),
+            "artist": entry.get("artist", ""),
+            "subtitle": entry.get("subtitle", ""),
+            "url": entry.get("url", ""),
+            "in_repo": bool(r),
+            "repo_path": r["path"] if r else None,
+            "repo_category": r["category_letter"] if r else None,
+        })
+    return jsonify({"items": out, "categories": list_categories()})
+
+
+@app.route("/api/doce/preview")
+def api_doce_preview():
+    doce_id = request.args.get("id", "").strip()
+    if not doce_id:
+        abort(400, "Falta id")
+    force = request.args.get("force") == "1"
+    include_meta = request.args.get("meta", "1") != "0"
+    try:
+        content, meta = da.fetch_and_adapt(
+            doce_id, use_cache=not force, include_meta=include_meta,
+        )
+    except Exception as e:
+        abort(502, f"Error descargando doceacordes id={doce_id}: {e}")
+    entry = da.get_entry(doce_id) or {}
+    # Sugerir slug y número
+    suggested_slug = d2c.slugify(d2c.pretty_title_case(meta.get("title") or entry.get("title", "")))
+    suggested_number = None
+    cat_letter = request.args.get("category", "").upper().strip()
+    if cat_letter:
+        cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
+        if cat:
+            suggested_number = d2c.next_song_number(SONGS_DIR / cat["folder"])
+    extras = parse_extra_meta(content)
+    return jsonify({
+        "id": doce_id,
+        "entry": entry,
+        "content": content,
+        "meta": meta,
+        "extras": extras,
+        "suggested_slug": suggested_slug,
+        "suggested_number": suggested_number,
+    })
+
+
+@app.route("/api/doce/suggest-number")
+def api_doce_suggest_number():
+    """Devuelve el siguiente número libre en una categoría dada."""
+    cat_letter = request.args.get("category", "").upper().strip()
+    cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
+    if not cat:
+        abort(404, "Categoría no encontrada")
+    folder = SONGS_DIR / cat["folder"]
+    return jsonify({"category": cat_letter, "next_number": d2c.next_song_number(folder)})
+
+
+@app.route("/api/doce/import", methods=["POST"])
+def api_doce_import():
+    """Importa canciones desde doceacordes.es.
+
+    Body: {items: [{doce_id, category_letter, number?, slug?, force_refresh?}]}
+    """
+    body = request.get_json(silent=True) or {}
+    items = body.get("items") or []
+    if not isinstance(items, list) or not items:
+        abort(400, "Falta items")
+    results = []
+    for it in items:
+        doce_id = str(it.get("doce_id") or "").strip()
+        cat_letter = (it.get("category_letter") or "").upper().strip()
+        force = bool(it.get("force_refresh"))
+        try:
+            if not doce_id:
+                raise ValueError("Falta doce_id")
+            if not cat_letter:
+                raise ValueError("Falta category_letter")
+            cat = next((c for c in list_categories() if c["letter"] == cat_letter), None)
+            if not cat:
+                raise ValueError(f"Categoría {cat_letter} no encontrada")
+            folder = SONGS_DIR / cat["folder"]
+            folder.mkdir(exist_ok=True)
+
+            include_meta = it.get("include_meta", True)
+            content, meta = da.fetch_and_adapt(
+                doce_id, use_cache=not force, include_meta=include_meta,
+            )
+
+            title = meta.get("title") or (da.get_entry(doce_id) or {}).get("title") or f"cancion-{doce_id}"
+            slug = it.get("slug") or d2c.slugify(d2c.pretty_title_case(title))
+            slug = re.sub(r"[^a-z0-9_]+", "_", slug.lower()).strip("_") or "cancion"
+
+            num = it.get("number")
+            if not (isinstance(num, int) and num > 0):
+                num = d2c.next_song_number(folder)
+            fname = f"{num:02d}.{slug}.cho"
+            fpath = folder / fname
+            if fpath.exists():
+                raise FileExistsError(f"Ya existe {fname}")
+            fpath.write_text(content, encoding="utf-8")
+            results.append({
+                "doce_id": doce_id,
+                "ok": True,
+                "path": str(fpath.relative_to(REPO_DIR)),
+                "title": title,
+            })
+        except Exception as e:
+            results.append({"doce_id": doce_id, "ok": False, "error": str(e)})
+    return jsonify({"results": results})
 
 
 # ─────────── API: reordenar y build-json ─────────── #

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -16,8 +16,19 @@ function app() {
     categoryFilter: '',
     search: '',
     statusFilter: '',       // '' | 'revisar' | 'revisar_acordes' | 'any' | 'none'
+    mediaFilter: '',        // '' | 'no_youtube' | 'no_audio' | 'no_media' | 'any_media'
     onlyInRepoFilter: false,
     selectedCatalogPaths: new Set(),
+
+    // Quick add link modal
+    quickLink: { open: false, path: '', songTitle: '', type: '', label: '', url: '',
+                 existing: [], saving: false },
+    // Editor multimedia tab
+    mediaForm: { rhythm: '', album: '', liturgicalTime: '', source: '', videoEmbed: '',
+                 comment: '', youtubeLinks: [], audioLinks: [] },
+    mediaOriginal: '',
+    mediaDirty: false,
+    mediaSaving: false,
 
     // Import view (docx)
     importSearch: '',
@@ -41,6 +52,24 @@ function app() {
     importingLatex: false,
     latexResults: [],
     latexPreview: null,
+
+    // Doceacordes
+    doceItems: [],
+    doceLoading: false,
+    doceSearch: '',
+    doceMatchFilter: '',
+    docePage: 0,
+    docePageSize: 50,
+    doceCategorySel: {},      // { doce_id: 'A' }
+    doceNumberSel: {},        // { doce_id: 12 }
+    doceSuggestedNumber: {},  // { doce_id: 7 }
+    doceResults: [],
+    doceImporting: false,
+    doceIncludeMeta: true,
+    docePreview: null,
+    docePreviewCategory: '',
+    docePreviewReloading: false,
+    doceCandidatesPopover: null,  // {missingId, anchor, candidates, sectionLetter}
 
     // Reorder
     reorderCategory: '',
@@ -126,6 +155,15 @@ function app() {
       else if (this.statusFilter === 'any')         list = list.filter(r => r.has_todo || r.has_chord_review);
       else if (this.statusFilter === 'none')        list = list.filter(r => !r.has_todo && !r.has_chord_review);
       if (this.onlyInRepoFilter) list = list.filter(r => !r.in_docx);
+      if (this.mediaFilter === 'no_youtube') {
+        list = list.filter(r => (r.youtube_count || 0) === 0 && !r.has_video);
+      } else if (this.mediaFilter === 'no_audio') {
+        list = list.filter(r => (r.audio_count || 0) === 0);
+      } else if (this.mediaFilter === 'no_media') {
+        list = list.filter(r => (r.youtube_count || 0) === 0 && !r.has_video && (r.audio_count || 0) === 0);
+      } else if (this.mediaFilter === 'any_media') {
+        list = list.filter(r => (r.youtube_count || 0) > 0 || r.has_video || (r.audio_count || 0) > 0);
+      }
       if (this.search) {
         const q = this.normalizeSearch(this.search);
         list = list.filter(r =>
@@ -341,6 +379,335 @@ function app() {
         this.importingLatex = false;
       }
     },
+    // ─────────── Import view (doceacordes.es) ───────────
+    async loadDoce(force = false) {
+      if (this.doceItems.length > 0 && !force) return;
+      this.doceLoading = true;
+      try {
+        const r = await fetch('/api/doce/list');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        this.doceItems = d.items || [];
+      } catch (e) {
+        alert('No pude cargar el índice de doceacordes: ' + e.message);
+      } finally {
+        this.doceLoading = false;
+      }
+    },
+    filteredDoce() {
+      let list = this.doceItems;
+      if (this.doceMatchFilter === 'new') list = list.filter(d => !d.in_repo);
+      else if (this.doceMatchFilter === 'match') list = list.filter(d => d.in_repo);
+      if (this.doceSearch) {
+        const q = this.normalizeSearch(this.doceSearch);
+        list = list.filter(d =>
+          this.normalizeSearch(d.title).includes(q) ||
+          this.normalizeSearch(d.artist).includes(q) ||
+          d.id.includes(q)
+        );
+      }
+      return list;
+    },
+    filteredDocePaged() {
+      const list = this.filteredDoce();
+      const start = this.docePage * this.docePageSize;
+      return list.slice(start, start + this.docePageSize);
+    },
+    async onDoceCategoryChange(doceId) {
+      const cat = this.doceCategorySel[doceId];
+      if (!cat) return;
+      try {
+        const r = await fetch('/api/doce/suggest-number?category=' + cat);
+        if (r.ok) {
+          const j = await r.json();
+          this.doceSuggestedNumber = { ...this.doceSuggestedNumber, [doceId]: j.next_number };
+          if (!this.doceNumberSel[doceId]) {
+            this.doceNumberSel = { ...this.doceNumberSel, [doceId]: j.next_number };
+          }
+        }
+      } catch (e) { /* silencio */ }
+    },
+    async previewDoce(doceId, force = false) {
+      try {
+        const cat = this.doceCategorySel[doceId] || '';
+        const url = '/api/doce/preview?id=' + encodeURIComponent(doceId) +
+                    (cat ? '&category=' + cat : '') +
+                    (this.doceIncludeMeta ? '' : '&meta=0') +
+                    (force ? '&force=1' : '');
+        const r = await fetch(url);
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const j = await r.json();
+        this.docePreview = j;
+        this.docePreviewCategory = cat;
+        if (j.suggested_number && !this.doceNumberSel[doceId]) {
+          this.doceNumberSel = { ...this.doceNumberSel, [doceId]: j.suggested_number };
+        }
+      } catch (e) {
+        alert('Error preview: ' + e.message);
+      }
+    },
+    async reloadDocePreview() {
+      if (!this.docePreview) return;
+      this.docePreviewReloading = true;
+      try {
+        await this.previewDoce(this.docePreview.id, true);
+      } finally {
+        this.docePreviewReloading = false;
+      }
+    },
+    hasExtras(extras) {
+      if (!extras) return false;
+      return !!(extras.rhythm || extras.album || extras.liturgicalTime || extras.source ||
+                extras.comment || extras.videoEmbed ||
+                (extras.youtubeLinks && extras.youtubeLinks.length) ||
+                (extras.audioLinks && extras.audioLinks.length));
+    },
+    async importFromPreview() {
+      if (!this.docePreview) return;
+      const id = this.docePreview.id;
+      this.doceCategorySel = { ...this.doceCategorySel, [id]: this.docePreviewCategory };
+      await this.importOneDoce(id);
+      this.docePreview = null;
+    },
+    async importOneDoce(doceId) {
+      const cat = this.doceCategorySel[doceId];
+      if (!cat) { alert('Elige categoría'); return; }
+      this.doceImporting = true;
+      try {
+        const item = {
+          doce_id: doceId,
+          category_letter: cat,
+          number: this.doceNumberSel[doceId] || undefined,
+          include_meta: this.doceIncludeMeta,
+        };
+        const r = await fetch('/api/doce/import', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: [item] }),
+        });
+        const json = await r.json();
+        this.doceResults = [...(json.results || []), ...this.doceResults].slice(0, 30);
+        // refrescar marcas in_repo
+        await this.loadDoce(true);
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error importando: ' + e.message);
+      } finally {
+        this.doceImporting = false;
+      }
+    },
+    onDoceBadgeClick(missing, event) {
+      // Si solo hay 1 candidato → ir directo al import
+      if (!missing.doce_candidates || missing.doce_candidates.length <= 1) {
+        this.doceCandidatesPopover = null;
+        this.goImportFromDoce(missing);
+        return;
+      }
+      // Toggle popover
+      if (this.doceCandidatesPopover && this.doceCandidatesPopover.missingId === missing.docx_id) {
+        this.doceCandidatesPopover = null;
+      } else {
+        this.doceCandidatesPopover = { missingId: missing.docx_id };
+      }
+    },
+    async pickDoceCandidate(missing, candidate) {
+      this.doceCandidatesPopover = null;
+      this.view = 'doce';
+      await this.loadDoce();
+      this.doceSearch = candidate.title;
+      this.docePage = 0;
+      if (missing.section_letter && !this.doceCategorySel[candidate.id]) {
+        this.doceCategorySel = { ...this.doceCategorySel, [candidate.id]: missing.section_letter };
+        await this.onDoceCategoryChange(candidate.id);
+      }
+      await this.previewDoce(candidate.id);
+      if (missing.section_letter) this.docePreviewCategory = missing.section_letter;
+    },
+    async goImportFromDoce(missing) {
+      // Llamado desde la vista "Importar del cantoral" al click en badge 🎸
+      // missing: {doce_candidates, title, section_letter, ...}
+      this.view = 'doce';
+      await this.loadDoce();
+      // Si hay un único candidato muy fiable, lo preselecciono con la sección sugerida
+      const cands = missing.doce_candidates || [];
+      if (cands.length === 0) return;
+      // Filtrar la tabla a esos candidatos
+      this.doceSearch = cands[0].title;
+      this.docePage = 0;
+      // Sugerir categoría del docx
+      for (const c of cands) {
+        if (missing.section_letter && !this.doceCategorySel[c.id]) {
+          this.doceCategorySel = { ...this.doceCategorySel, [c.id]: missing.section_letter };
+          this.onDoceCategoryChange(c.id);
+        }
+      }
+      // Si sólo hay uno, abrir preview directamente
+      if (cands.length === 1) {
+        await this.previewDoce(cands[0].id);
+        if (missing.section_letter) this.docePreviewCategory = missing.section_letter;
+      }
+    },
+
+    // ─────────── Multimedia / quick add ───────────
+    mediaYoutubeTooltip(r) {
+      const n = (r.youtube_count || 0) + (r.has_video ? 1 : 0);
+      if (n === 0) return 'Sin YouTube ni vídeo — click para añadir';
+      return `${n} link${n > 1 ? 's' : ''} de YouTube/vídeo · click para añadir más`;
+    },
+    mediaAudioTooltip(r) {
+      const n = r.audio_count || 0;
+      if (n === 0) return 'Sin audio interno — click para añadir';
+      return `${n} audio${n > 1 ? 's' : ''} interno${n > 1 ? 's' : ''} · click para añadir más`;
+    },
+    async openQuickAddLink(repoSong, type) {
+      // Carga el .cho actual para listar los links existentes
+      let existing = [];
+      try {
+        const r = await fetch('/api/song?path=' + encodeURIComponent(repoSong.path));
+        if (r.ok) {
+          const j = await r.json();
+          existing = type === 'youtube'
+            ? (j.meta.youtubeLinks || [])
+            : (j.meta.audioLinks || []);
+        }
+      } catch (_) { /* silence */ }
+      this.quickLink = {
+        open: true, path: repoSong.path, songTitle: repoSong.title,
+        type, label: '', url: '', existing, saving: false,
+      };
+    },
+    async removeQuickLink(idx) {
+      // Borra un link existente (reescribe meta entera sin él)
+      if (!confirm('¿Borrar este link?')) return;
+      try {
+        const r = await fetch('/api/song?path=' + encodeURIComponent(this.quickLink.path));
+        const j = await r.json();
+        const key = this.quickLink.type === 'youtube' ? 'youtubeLinks' : 'audioLinks';
+        const list = (j.meta[key] || []).slice();
+        list.splice(idx, 1);
+        const meta = { ...j.meta, [key]: list };
+        const r2 = await fetch('/api/song/meta?path=' + encodeURIComponent(this.quickLink.path), {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(meta),
+        });
+        if (!r2.ok) throw new Error('HTTP ' + r2.status);
+        this.quickLink.existing = list;
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error: ' + e.message);
+      }
+    },
+    async saveQuickAddLink() {
+      if (!this.quickLink.url) return;
+      this.quickLink.saving = true;
+      try {
+        const r = await fetch('/api/song/meta/quick-add', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            path: this.quickLink.path,
+            type: this.quickLink.type,
+            label: this.quickLink.label,
+            url: this.quickLink.url,
+          }),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const j = await r.json();
+        // Actualizar lista existente + refrescar catálogo
+        const key = this.quickLink.type === 'youtube' ? 'youtubeLinks' : 'audioLinks';
+        this.quickLink.existing = j.meta[key] || [];
+        this.quickLink.label = '';
+        this.quickLink.url = '';
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error: ' + e.message);
+      } finally {
+        this.quickLink.saving = false;
+      }
+    },
+    async openMultimediaTab(path) {
+      this.quickLink.open = false;
+      await this.openEditor(path);
+      this.setEditorTab('media');
+    },
+
+    // Tab Multimedia del editor
+    loadMediaForm() {
+      const m = this.editor.meta || {};
+      this.mediaForm = {
+        rhythm: m.rhythm || '',
+        album: m.album || '',
+        liturgicalTime: m.liturgicalTime || '',
+        source: m.source || '',
+        videoEmbed: m.videoEmbed || '',
+        comment: m.comment || '',
+        youtubeLinks: (m.youtubeLinks || []).map(l => ({ ...l })),
+        audioLinks: (m.audioLinks || []).map(l => ({ ...l })),
+      };
+      this.mediaOriginal = JSON.stringify(this.mediaForm);
+      this.mediaDirty = false;
+    },
+    resetMediaMeta() { this.loadMediaForm(); },
+    addMediaLink(key) {
+      this.mediaForm[key] = [...this.mediaForm[key], { label: '', url: '' }];
+      this.mediaDirty = true;
+    },
+    removeMediaLink(key, idx) {
+      const arr = this.mediaForm[key].slice();
+      arr.splice(idx, 1);
+      this.mediaForm[key] = arr;
+      this.mediaDirty = true;
+    },
+    moveMediaLink(key, idx, delta) {
+      const arr = this.mediaForm[key].slice();
+      const j = idx + delta;
+      if (j < 0 || j >= arr.length) return;
+      [arr[idx], arr[j]] = [arr[j], arr[idx]];
+      this.mediaForm[key] = arr;
+      this.mediaDirty = true;
+    },
+    async saveMediaMeta() {
+      if (!this.editor.path) return;
+      // Bug 1: si hay cambios sin guardar en el cuerpo (visual/raw), avisar
+      if (this.editor.dirty) {
+        const choice = confirm(
+          'Tienes cambios en el cuerpo de la canción SIN GUARDAR.\n\n' +
+          'Si continúas guardando solo los metadatos, los cambios del cuerpo se perderán ' +
+          '(se recargará desde disco).\n\n' +
+          'Pulsa Aceptar para PRIMERO guardar el cuerpo y LUEGO los metadatos.\n' +
+          'Pulsa Cancelar para abortar (vuelve al editor y guarda manualmente).'
+        );
+        if (!choice) return;
+        // Guardar cuerpo primero
+        await this.saveSong();
+        if (this.editor.dirty) return; // saveSong falló
+      }
+      this.mediaSaving = true;
+      try {
+        // Limpiar links vacíos
+        const payload = { ...this.mediaForm,
+          youtubeLinks: this.mediaForm.youtubeLinks.filter(l => l.url && l.url.trim()),
+          audioLinks: this.mediaForm.audioLinks.filter(l => l.url && l.url.trim()),
+        };
+        const r = await fetch('/api/song/meta?path=' + encodeURIComponent(this.editor.path), {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        // Refrescar editor content (el cuerpo del .cho cambió por las directives)
+        const r2 = await fetch('/api/song?path=' + encodeURIComponent(this.editor.path));
+        const sj = await r2.json();
+        this.editor.content = sj.content;
+        this.editor.originalContent = sj.content;
+        this.editor.meta = sj.meta;
+        this.loadMediaForm();
+        await this.loadCatalog();
+      } catch (e) {
+        alert('Error guardando metadatos: ' + e.message);
+      } finally {
+        this.mediaSaving = false;
+      }
+    },
+
     async openSongFromPath(path) {
       // Reusa la apertura del editor por path
       try {
@@ -442,11 +809,19 @@ function app() {
       this.setSaveIndicator('saved', 'Sin cambios');
     },
     setEditorTab(t) {
+      // Warn si dejamos el tab media con cambios sin guardar
+      if (this.editor.tab === 'media' && t !== 'media' && this.mediaDirty) {
+        if (!confirm('Hay metadatos sin guardar en el tab Multimedia. ¿Descartar cambios?')) return;
+        this.loadMediaForm(); // resetea
+      }
       if (this.editor.tab === 'visual' && t !== 'visual') {
         this.editor.content = serializeCho(this.editor.parsed);
         this.refreshMetaFromRaw();
       }
       this.editor.tab = t;
+      if (t === 'media') {
+        this.loadMediaForm();
+      }
       if (t === 'visual') {
         this.editor.parsed = parseCho(this.editor.content);
         this.markChorusFlags();

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -63,6 +63,7 @@ function app() {
     doceCategorySel: {},      // { doce_id: 'A' }
     doceNumberSel: {},        // { doce_id: 12 }
     doceSuggestedNumber: {},  // { doce_id: 7 }
+    docePositionHint: {},     // { doce_id: 22 } proveniente de cantoral DOCX
     doceResults: [],
     doceImporting: false,
     doceIncludeMeta: true,
@@ -73,8 +74,8 @@ function app() {
 
     // Reorder
     reorderCategory: '',
-    reorderSongs: [],
-    reorderModified: false,
+    reorderSlots: [],              // [{number, filename, title, gap: bool}]
+    reorderOriginal: '',
     reorderDragIdx: null,
 
     // Editor
@@ -95,6 +96,9 @@ function app() {
     visualChordClipboard: null,   // [{lyric, chords}]  patrón copiado
     clipboardInfo: '',            // texto persistente cuando hay acordes copiados
     showHelp: false,
+    // Cola de revisión: tras importar varias, abre el editor en secuencia
+    editorQueue: [],            // [{path, source, label}]
+    editorQueueIdx: 0,
     newSong: { open: false, category: '', title: '', artist: '', key: '', capo: 0,
                mode: 'blank', content: '', creating: false },
     saveIndicator: { text: 'Sin cambios', cls: 'saved' },
@@ -209,6 +213,9 @@ function app() {
         this.importResults = json.results || [];
         this.selectedImports = new Set();
         await this.loadCatalog();
+        // Abrir editor de las importadas con éxito, en cola
+        const paths = this.importResults.filter(r => r.ok && r.path).map(r => r.path);
+        this.enqueueAndOpen(paths, 'del cantoral');
       } catch (e) {
         alert('Error importando: ' + e.message);
       } finally {
@@ -370,9 +377,12 @@ function app() {
           body: JSON.stringify({ items, move_to_processed: true }),
         });
         const json = await r.json();
-        this.latexResults = [...this.latexResults, ...(json.results || [])];
+        const newResults = json.results || [];
+        this.latexResults = [...this.latexResults, ...newResults];
         this.selectedLatex = new Set();
         await Promise.all([this.loadCatalog(), this.loadLatex(true)]);
+        const paths = newResults.filter(r => r.ok && r.path).map(r => r.path);
+        this.enqueueAndOpen(paths, 'de LaTeX');
       } catch (e) {
         alert('Error importando LaTeX: ' + e.message);
       } finally {
@@ -417,11 +427,15 @@ function app() {
       const cat = this.doceCategorySel[doceId];
       if (!cat) return;
       try {
-        const r = await fetch('/api/doce/suggest-number?category=' + cat);
+        const hint = this.docePositionHint[doceId];
+        const url = '/api/doce/suggest-number?category=' + cat +
+                    (hint ? '&position_hint=' + hint : '');
+        const r = await fetch(url);
         if (r.ok) {
           const j = await r.json();
           this.doceSuggestedNumber = { ...this.doceSuggestedNumber, [doceId]: j.next_number };
-          if (!this.doceNumberSel[doceId]) {
+          // Si el usuario NO había puesto número, o si tenemos un hint específico, usarlo
+          if (!this.doceNumberSel[doceId] || hint) {
             this.doceNumberSel = { ...this.doceNumberSel, [doceId]: j.next_number };
           }
         }
@@ -430,10 +444,12 @@ function app() {
     async previewDoce(doceId, force = false) {
       try {
         const cat = this.doceCategorySel[doceId] || '';
+        const hint = this.docePositionHint[doceId];
         const url = '/api/doce/preview?id=' + encodeURIComponent(doceId) +
                     (cat ? '&category=' + cat : '') +
                     (this.doceIncludeMeta ? '' : '&meta=0') +
-                    (force ? '&force=1' : '');
+                    (force ? '&force=1' : '') +
+                    (hint ? '&position_hint=' + hint : '');
         const r = await fetch(url);
         if (!r.ok) throw new Error('HTTP ' + r.status);
         const j = await r.json();
@@ -478,6 +494,7 @@ function app() {
           doce_id: doceId,
           category_letter: cat,
           number: this.doceNumberSel[doceId] || undefined,
+          position_hint: this.docePositionHint[doceId] || undefined,
           include_meta: this.doceIncludeMeta,
         };
         const r = await fetch('/api/doce/import', {
@@ -486,10 +503,12 @@ function app() {
           body: JSON.stringify({ items: [item] }),
         });
         const json = await r.json();
-        this.doceResults = [...(json.results || []), ...this.doceResults].slice(0, 30);
-        // refrescar marcas in_repo
+        const newResults = json.results || [];
+        this.doceResults = [...newResults, ...this.doceResults].slice(0, 30);
         await this.loadDoce(true);
         await this.loadCatalog();
+        const paths = newResults.filter(r => r.ok && r.path).map(r => r.path);
+        this.enqueueAndOpen(paths, 'de doceacordes');
       } catch (e) {
         alert('Error importando: ' + e.message);
       } finally {
@@ -516,6 +535,11 @@ function app() {
       await this.loadDoce();
       this.doceSearch = candidate.title;
       this.docePage = 0;
+      // Guardar la posición que esta canción tiene en el cantoral DOCX para
+      // que el número de archivo coincida (si está libre).
+      if (missing.position_in_section) {
+        this.docePositionHint = { ...this.docePositionHint, [candidate.id]: missing.position_in_section };
+      }
       if (missing.section_letter && !this.doceCategorySel[candidate.id]) {
         this.doceCategorySel = { ...this.doceCategorySel, [candidate.id]: missing.section_letter };
         await this.onDoceCategoryChange(candidate.id);
@@ -534,11 +558,14 @@ function app() {
       // Filtrar la tabla a esos candidatos
       this.doceSearch = cands[0].title;
       this.docePage = 0;
-      // Sugerir categoría del docx
+      // Sugerir categoría del docx + posición del cantoral
       for (const c of cands) {
+        if (missing.position_in_section) {
+          this.docePositionHint = { ...this.docePositionHint, [c.id]: missing.position_in_section };
+        }
         if (missing.section_letter && !this.doceCategorySel[c.id]) {
           this.doceCategorySel = { ...this.doceCategorySel, [c.id]: missing.section_letter };
-          this.onDoceCategoryChange(c.id);
+          await this.onDoceCategoryChange(c.id);
         }
       }
       // Si sólo hay uno, abrir preview directamente
@@ -731,23 +758,57 @@ function app() {
     // ─────────── Reorder ───────────
     async loadReorder() {
       if (!this.reorderCategory) {
-        this.reorderSongs = [];
-        this.reorderModified = false;
+        this.reorderSlots = [];
+        this.reorderOriginal = '';
         return;
       }
-      this.reorderSongs = this.data.repo_songs
-        .filter(r => r.category_letter === this.reorderCategory)
-        .sort((a, b) => (a.number || 999) - (b.number || 999));
-      this.reorderModified = false;
+      try {
+        const r = await fetch('/api/category/slots?category=' + this.reorderCategory);
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const j = await r.json();
+        // Enriquecer con título buscando en repo_songs
+        const byFn = {};
+        for (const rs of this.data.repo_songs) byFn[rs.filename] = rs;
+        this.reorderSlots = j.slots.map(s => {
+          const info = s.filename ? byFn[s.filename] : null;
+          return {
+            number: s.number,
+            filename: s.filename,
+            title: info ? info.title : null,
+            originalNumber: info ? info.number : null,
+            gap: !s.filename,
+          };
+        });
+        this.reorderOriginal = JSON.stringify(this.reorderSlots.map(s => s.filename));
+      } catch (e) {
+        alert('No pude cargar slots: ' + e.message);
+      }
+    },
+    get reorderModified() {
+      return JSON.stringify((this.reorderSlots || []).map(s => s.filename)) !== this.reorderOriginal;
     },
     onReorderDrop(targetIdx) {
       if (this.reorderDragIdx == null || this.reorderDragIdx === targetIdx) return;
-      const arr = this.reorderSongs;
+      const arr = this.reorderSlots;
       const [moved] = arr.splice(this.reorderDragIdx, 1);
       arr.splice(targetIdx, 0, moved);
-      this.reorderSongs = [...arr];
-      this.reorderModified = true;
+      this.reorderSlots = [...arr];
       this.reorderDragIdx = null;
+    },
+    insertGapAt(idx) {
+      const arr = [...this.reorderSlots];
+      arr.splice(idx, 0, { number: null, filename: null, title: null, gap: true });
+      this.reorderSlots = arr;
+    },
+    removeGapAt(idx) {
+      if (!this.reorderSlots[idx]?.gap) return;
+      const arr = [...this.reorderSlots];
+      arr.splice(idx, 1);
+      this.reorderSlots = arr;
+    },
+    compactGaps() {
+      if (!confirm('¿Compactar todos los huecos? Renumera consecutivo 01, 02, 03…')) return;
+      this.reorderSlots = this.reorderSlots.filter(s => !s.gap);
     },
     async applyReorder() {
       if (!this.reorderCategory || !this.reorderModified) return;
@@ -757,10 +818,13 @@ function app() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             category: this.reorderCategory,
-            order: this.reorderSongs.map(s => s.filename),
+            order: this.reorderSlots.map(s => s.filename),  // null = hueco
           }),
         });
-        if (!r.ok) throw new Error('HTTP ' + r.status);
+        if (!r.ok) {
+          const t = await r.text();
+          throw new Error('HTTP ' + r.status + ': ' + t);
+        }
         await this.loadCatalog();
         await this.loadReorder();
         alert('Orden aplicado.');
@@ -807,6 +871,42 @@ function app() {
       this.visualSelectedLines = new Set();
       this.visualSelectedChord = null;
       this.setSaveIndicator('saved', 'Sin cambios');
+      // Si hay cola pendiente, avanzar a la siguiente
+      this.advanceEditorQueue();
+    },
+    // ─────────── Cola de revisión post-import ───────────
+    enqueueAndOpen(paths, label = 'importadas') {
+      const list = (paths || []).filter(Boolean);
+      if (!list.length) return;
+      this.editorQueue = list.map(p => ({ path: p, label }));
+      this.editorQueueIdx = 0;
+      this.openEditor(list[0]);
+    },
+    advanceEditorQueue() {
+      if (!this.editorQueue.length) return;
+      this.editorQueueIdx++;
+      if (this.editorQueueIdx >= this.editorQueue.length) {
+        this.editorQueue = [];
+        this.editorQueueIdx = 0;
+        return;
+      }
+      const next = this.editorQueue[this.editorQueueIdx];
+      // pequeño delay para que Alpine cierre el modal antes de reabrirlo
+      setTimeout(() => this.openEditor(next.path), 50);
+    },
+    skipEditorQueue() {
+      if (this.editor.dirty && !confirm('Hay cambios sin guardar. ¿Saltar igualmente?')) return;
+      // Cierra sin pasar por confirm interno de closeEditor
+      this.editor.dirty = false;
+      this.closeEditor();
+    },
+    cancelEditorQueue() {
+      this.editorQueue = [];
+      this.editorQueueIdx = 0;
+    },
+    editorQueueProgress() {
+      if (!this.editorQueue.length) return '';
+      return `${this.editorQueueIdx + 1} / ${this.editorQueue.length}`;
     },
     setEditorTab(t) {
       // Warn si dejamos el tab media con cambios sin guardar

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -780,9 +780,9 @@
   <!-- REORDENAR -->
   <section x-show="view === 'reorder' && data" x-cloak>
     <h1>🔀 Reordenar canciones</h1>
-    <p class="muted">Elige una categoría, arrastra para reordenar y pulsa <em>Aplicar</em>. Los archivos
-       se renumerarán (<code>01., 02., …</code>) manteniendo el slug. Se hace backup en
-       <code>songs-backup-edits/</code>.</p>
+    <p class="muted">Elige una categoría, arrastra para reordenar y pulsa <em>Aplicar</em>.
+       Puedes <strong>dejar huecos</strong> entre canciones (líneas grises) y se respetarán
+       en el numerado. Se hace backup en <code>songs-backup-edits/</code>.</p>
     <div class="filter-bar">
       <select x-model="reorderCategory" @change="loadReorder()">
         <option value="">— Elige categoría —</option>
@@ -792,19 +792,38 @@
       </select>
       <button class="btn primary" :disabled="!reorderModified" @click="applyReorder()">Aplicar nuevo orden</button>
       <button x-show="reorderModified" @click="loadReorder()">Cancelar cambios</button>
+      <template x-if="reorderCategory && reorderSlots.length > 0">
+        <button @click="insertGapAt(reorderSlots.length)" title="Añade un slot vacío al final">➕ Insertar hueco</button>
+      </template>
+      <template x-if="reorderCategory && reorderSlots.some(s => s.gap)">
+        <button @click="compactGaps()" title="Quita todos los huecos y deja números consecutivos">📐 Compactar huecos</button>
+      </template>
     </div>
 
     <ul class="reorder-list" x-show="reorderCategory">
-      <template x-for="(s, idx) in reorderSongs" :key="s.path">
+      <template x-for="(s, idx) in reorderSlots" :key="(s.filename || 'gap-') + idx">
         <li draggable="true"
+            :class="{ 'reorder-gap': s.gap }"
             @dragstart="reorderDragIdx = idx"
             @dragover.prevent
             @drop="onReorderDrop(idx)">
           <span class="grip">⋮⋮</span>
           <span class="new-num" x-text="(idx + 1).toString().padStart(2,'0')"></span>
-          <span class="old-num" x-text="s.number != null ? `(was ${s.number.toString().padStart(2,'0')})` : ''"></span>
-          <span class="title" x-text="s.title"></span>
-          <span class="filename" x-text="s.filename"></span>
+          <template x-if="!s.gap">
+            <span class="reorder-row-main">
+              <span class="old-num" x-text="s.originalNumber != null && s.originalNumber !== (idx + 1) ? `(was ${s.originalNumber.toString().padStart(2,'0')})` : ''"></span>
+              <span class="title" x-text="s.title"></span>
+              <span class="filename" x-text="s.filename"></span>
+              <button class="link-mini" @click="insertGapAt(idx + 1)"
+                      title="Insertar hueco justo después">➕ hueco aquí</button>
+            </span>
+          </template>
+          <template x-if="s.gap">
+            <span class="reorder-row-main">
+              <span class="gap-label">— hueco vacío —</span>
+              <button class="link-mini" @click="removeGapAt(idx)" title="Quitar este hueco">✕ quitar</button>
+            </span>
+          </template>
         </li>
       </template>
     </ul>
@@ -883,8 +902,15 @@
           <span class="status-pill status-acordes" x-show="editor.meta.has_chord_review">🎵 Revisar acordes</span>
         </h2>
         <div class="editor-actions">
+          <span class="queue-progress" x-show="editorQueue.length > 0" x-cloak>
+            📥 Revisando importadas: <strong x-text="editorQueueProgress()"></strong>
+            <button class="link-mini" @click="skipEditorQueue()" title="Siguiente sin guardar">⏭ saltar</button>
+            <button class="link-mini" @click="cancelEditorQueue()" title="Salir de la cola">✕ cola</button>
+          </span>
           <button class="btn primary" :disabled="!editor.dirty" @click="saveSong()">💾 Guardar</button>
-          <button class="btn" @click="closeEditor()">✕ Cerrar</button>
+          <button class="btn" @click="closeEditor()">
+            <span x-text="editorQueue.length > 0 && editorQueueIdx + 1 < editorQueue.length ? '✕ Cerrar y siguiente →' : '✕ Cerrar'"></span>
+          </button>
         </div>
       </div>
 

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -26,6 +26,7 @@
     <a :class="{active: view === 'catalog'}" @click.prevent="view = 'catalog'; categoryFilter = ''" href="#">📋 Catálogo</a>
     <a :class="{active: view === 'import'}" @click.prevent="view = 'import'" href="#">📥 Importar del cantoral</a>
     <a :class="{active: view === 'latex'}" @click.prevent="view = 'latex'; loadLatex()" href="#">📐 Importar de LaTeX</a>
+    <a :class="{active: view === 'doce'}" @click.prevent="view = 'doce'; loadDoce()" href="#">🎸 Importar de doceacordes</a>
     <a :class="{active: view === 'reorder'}" @click.prevent="view = 'reorder'" href="#">🔀 Reordenar</a>
     <a :class="{active: view === 'backups'}" @click.prevent="view = 'backups'; loadBackups()" href="#">🗂 Backups</a>
   </nav>
@@ -66,34 +67,81 @@
   <!-- DASHBOARD -->
   <section x-show="view === 'dashboard' && data" x-cloak>
     <h1>📊 Dashboard</h1>
-    <div class="stats-grid">
-      <div class="stat">
-        <div class="stat-val" x-text="data.stats.repo_total"></div>
-        <div class="stat-lbl">canciones en el repo</div>
+
+    <div class="stats-group">
+      <h3 class="stats-group-title">📚 Catálogo</h3>
+      <div class="stats-grid">
+        <div class="stat">
+          <div class="stat-val" x-text="data.stats.repo_total"></div>
+          <div class="stat-lbl">canciones en el repo</div>
+        </div>
+        <div class="stat">
+          <div class="stat-val" x-text="data.stats.docx_total"></div>
+          <div class="stat-lbl">canciones en el cantoral</div>
+        </div>
+        <div class="stat info">
+          <div class="stat-val" x-text="data.stats.only_in_repo"></div>
+          <div class="stat-lbl">solo en repo (manuales)</div>
+        </div>
       </div>
-      <div class="stat">
-        <div class="stat-val" x-text="data.stats.docx_total"></div>
-        <div class="stat-lbl">canciones en el cantoral</div>
+    </div>
+
+    <div class="stats-group">
+      <h3 class="stats-group-title">📝 Pendiente de revisión</h3>
+      <div class="stats-grid">
+        <div class="stat warn">
+          <div class="stat-val" x-text="data.stats.missing_from_repo"></div>
+          <div class="stat-lbl">faltan en el repo</div>
+        </div>
+        <div class="stat todo" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar'">
+          <div class="stat-val" x-text="data.stats.todo_count"></div>
+          <div class="stat-lbl">📝 revisar canción</div>
+        </div>
+        <div class="stat chord-review" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar_acordes'">
+          <div class="stat-val" x-text="data.stats.chord_review_count"></div>
+          <div class="stat-lbl">🎵 revisar acordes</div>
+        </div>
       </div>
-      <div class="stat warn">
-        <div class="stat-val" x-text="data.stats.missing_from_repo"></div>
-        <div class="stat-lbl">faltan en el repo</div>
+    </div>
+
+    <div class="stats-group">
+      <h3 class="stats-group-title">📥 Fuentes de importación</h3>
+      <div class="stats-grid">
+        <div class="stat" style="background: rgba(139, 92, 246, 0.10); cursor: pointer" @click="view = 'latex'; loadLatex()">
+          <div class="stat-val" x-text="(data.stats.latex_new || 0) + '/' + (data.stats.latex_total || 0)"></div>
+          <div class="stat-lbl">📐 nuevas / total en LaTeX</div>
+        </div>
+        <div class="stat" style="background: rgba(234, 88, 12, 0.10); cursor: pointer"
+             @click="view = 'doce'; loadDoce()">
+          <div class="stat-val" x-text="'1.6k+'"></div>
+          <div class="stat-lbl">🎸 disponibles en doceacordes.es</div>
+        </div>
       </div>
-      <div class="stat todo" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar'">
-        <div class="stat-val" x-text="data.stats.todo_count"></div>
-        <div class="stat-lbl">📝 pendientes revisar canción</div>
-      </div>
-      <div class="stat chord-review" style="cursor:pointer" @click="view='catalog'; statusFilter='revisar_acordes'">
-        <div class="stat-val" x-text="data.stats.chord_review_count"></div>
-        <div class="stat-lbl">🎵 pendientes revisar acordes</div>
-      </div>
-      <div class="stat info">
-        <div class="stat-val" x-text="data.stats.only_in_repo"></div>
-        <div class="stat-lbl">solo en repo (manuales)</div>
-      </div>
-      <div class="stat" style="background: rgba(139, 92, 246, 0.10); cursor: pointer" @click="view = 'latex'; loadLatex()">
-        <div class="stat-val" x-text="(data.stats.latex_new || 0) + '/' + (data.stats.latex_total || 0)"></div>
-        <div class="stat-lbl">📐 nuevas / total en LaTeX</div>
+    </div>
+
+    <div class="stats-group">
+      <h3 class="stats-group-title">🎬 Multimedia</h3>
+      <div class="stats-grid">
+        <div class="stat" style="background: rgba(14, 165, 233, 0.10); cursor: pointer"
+             @click="view='catalog'; mediaFilter='any_media'; categoryFilter=''"
+             title="Canciones con vídeo, YouTube o audio">
+          <div class="stat-val">
+            <span x-text="(data.stats.with_youtube || 0)"></span><span class="muted" style="font-size:13px"> / </span><span class="muted" style="font-size:13px" x-text="(data.stats.with_audio || 0)"></span>
+          </div>
+          <div class="stat-lbl">📺 con YouTube · 🎧 con Audio</div>
+        </div>
+        <div class="stat" style="background: rgba(239, 68, 68, 0.10); cursor: pointer"
+             @click="view='catalog'; mediaFilter='no_youtube'; categoryFilter=''"
+             title="Canciones sin link de YouTube ni vídeo">
+          <div class="stat-val" x-text="data.stats.without_youtube || 0"></div>
+          <div class="stat-lbl">📺 sin YouTube/Vídeo</div>
+        </div>
+        <div class="stat" style="background: rgba(20, 184, 166, 0.10); cursor: pointer"
+             @click="view='catalog'; mediaFilter='no_audio'; categoryFilter=''"
+             title="Canciones sin audio interno">
+          <div class="stat-val" x-text="data.stats.without_audio || 0"></div>
+          <div class="stat-lbl">🎧 sin Audio</div>
+        </div>
       </div>
     </div>
     <div class="actions-row">
@@ -132,8 +180,15 @@
         <option value="revisar_acordes">🎵 Pendiente revisar acordes</option>
         <option value="none">✅ Sin revisión pendiente</option>
       </select>
+      <select x-model="mediaFilter" class="status-filter-select" title="Filtrar por multimedia">
+        <option value="">📺🎧 Cualquier multimedia</option>
+        <option value="no_youtube">📺 Sin YouTube/Vídeo</option>
+        <option value="no_audio">🎧 Sin audio</option>
+        <option value="no_media">∅ Sin nada multimedia</option>
+        <option value="any_media">★ Con algo multimedia</option>
+      </select>
       <label><input type="checkbox" x-model="onlyInRepoFilter" /> Solo manuales</label>
-      <button @click="search=''; statusFilter=''; onlyInRepoFilter=false; categoryFilter=''; clearCatalogSelect()">Limpiar</button>
+      <button @click="search=''; statusFilter=''; mediaFilter=''; onlyInRepoFilter=false; categoryFilter=''; clearCatalogSelect()">Limpiar</button>
       <span class="count" x-text="filteredRepoSongs().length + ' canciones'"></span>
     </div>
 
@@ -158,6 +213,7 @@
           <th>Autor</th>
           <th style="width:46px">Tono</th>
           <th style="width:90px">Categoría</th>
+          <th style="width:80px" title="Multimedia">🎬</th>
           <th style="width:130px">Estado revisión</th>
           <th>Acciones</th>
         </tr>
@@ -174,6 +230,22 @@
             <td style="color:var(--fg-2)" x-text="r.artist"></td>
             <td style="font-family:monospace;font-size:12px" x-text="r.key"></td>
             <td style="font-size:12px;color:var(--fg-3)" x-text="r.category_letter"></td>
+            <td class="media-cell">
+              <button class="media-icon" :class="{ active: r.has_video || r.youtube_count > 0 }"
+                      :title="mediaYoutubeTooltip(r)"
+                      @click.stop="openQuickAddLink(r, 'youtube')">
+                <span x-text="(r.youtube_count > 0 || r.has_video) ? '📺' : '➕📺'"></span>
+                <span x-show="r.youtube_count + (r.has_video ? 1 : 0) > 0"
+                      class="media-count"
+                      x-text="r.youtube_count + (r.has_video ? 1 : 0)"></span>
+              </button>
+              <button class="media-icon" :class="{ active: r.audio_count > 0 }"
+                      :title="mediaAudioTooltip(r)"
+                      @click.stop="openQuickAddLink(r, 'audio')">
+                <span x-text="r.audio_count > 0 ? '🎧' : '➕🎧'"></span>
+                <span x-show="r.audio_count > 0" class="media-count" x-text="r.audio_count"></span>
+              </button>
+            </td>
             <td>
               <span class="status-pill status-revisar" x-show="r.has_todo">📝 Revisar</span>
               <span class="status-pill status-acordes" x-show="r.has_chord_review">🎵 Acordes</span>
@@ -218,7 +290,7 @@
       </thead>
       <tbody>
         <template x-for="m in filteredMissing()" :key="m.docx_id">
-          <tr :class="{ 'has-warn': m.warnings.length > 0, 'has-latex': m.latex_available }">
+          <tr :class="{ 'has-warn': m.warnings.length > 0, 'has-latex': m.latex_available, 'has-doce': m.doce_available }">
             <td>
               <input type="checkbox"
                      :checked="selectedImports.has(m.docx_id)"
@@ -227,10 +299,50 @@
             <td x-text="m.section_letter"></td>
             <td>
               <a href="#" @click.prevent="previewDocx(m.docx_id)" x-text="m.title"></a>
-              <span x-show="m.latex_available"
+              <template x-if="m.doce_available">
+                <span class="badge-doce-wrap">
+                  <span class="badge-doce"
+                        :title="m.doce_candidates.length === 1
+                                  ? 'Importar desde doceacordes.es (recomendado)'
+                                  : 'Hay ' + m.doce_candidates.length + ' candidatos — click para elegir'"
+                        @click.stop="onDoceBadgeClick(m, $event)">🎸 en doceacordes
+                    <span x-show="m.doce_candidates.length > 1"
+                          x-text="'(' + m.doce_candidates.length + ')'"></span>
+                  </span>
+                  <!-- Popover candidatos -->
+                  <div class="doce-popover"
+                       x-show="doceCandidatesPopover && doceCandidatesPopover.missingId === m.docx_id"
+                       @click.outside="doceCandidatesPopover = null"
+                       x-cloak>
+                    <div class="doce-popover-head">
+                      🎸 Elige qué canción de doceacordes:
+                      <button class="link-mini" @click.stop="doceCandidatesPopover = null">✕</button>
+                    </div>
+                    <template x-for="(c, i) in m.doce_candidates" :key="c.id">
+                      <div class="doce-cand"
+                           @click.stop="pickDoceCandidate(m, c)">
+                        <div class="doce-cand-main">
+                          <span class="doce-cand-num">#<span x-text="c.id"></span></span>
+                          <span class="doce-cand-title" x-text="c.title"></span>
+                          <span class="doce-cand-score" x-text="Math.round(c._score) + '%'"></span>
+                        </div>
+                        <div class="doce-cand-sub">
+                          <span x-text="c.artist || '(sin autor)'"></span>
+                          <span x-show="c.subtitle" x-text="'· ' + c.subtitle"></span>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </span>
+              </template>
+              <span x-show="m.latex_available && !m.doce_available"
                     class="badge-latex"
                     title="Esta canción también está en LaTeX — se recomienda importarla desde LaTeX (mejor calidad)"
                     @click.stop="view = 'latex'; loadLatex().then(() => filterLatexById(m.latex_id))">📐 también en LaTeX</span>
+              <span x-show="m.latex_available && m.doce_available"
+                    class="badge-latex-mini"
+                    title="También en LaTeX"
+                    @click.stop="view = 'latex'; loadLatex().then(() => filterLatexById(m.latex_id))">📐 LaTeX</span>
             </td>
             <td x-text="m.key"></td>
             <td x-text="m.capo || ''"></td>
@@ -423,6 +535,225 @@
     </div>
   </section>
 
+  <!-- IMPORTAR DOCEACORDES -->
+  <section x-show="view === 'doce' && data" x-cloak>
+    <h1>🎸 Importar de doceacordes.es</h1>
+    <p class="muted">
+      Catálogo de <strong x-text="doceItems.length"></strong> canciones de
+      <a href="https://doceacordes.es" target="_blank">doceacordes.es</a>.
+      Se descarga el ChordPro original, se adapta al estilo MCM
+      (<code>{soc}</code>/<code>{eoc}</code>, acordes en inglés) y se guarda con
+      <code>{comment: TO DO: PENDIENTE REVISIÓN ACORDES}</code> al inicio.
+    </p>
+    <p class="muted" style="font-size:11px">
+      <strong>Tiene prioridad sobre LaTeX y DOCX</strong> — si una canción aparece
+      aquí, importa desde aquí (los acordes están bien posicionados y revisados).
+    </p>
+
+    <div class="filter-bar">
+      <input type="search" placeholder="Buscar título o autor…" x-model="doceSearch" />
+      <select x-model="doceMatchFilter">
+        <option value="">Todas</option>
+        <option value="new">Sólo nuevas (no en repo)</option>
+        <option value="match">Ya en repo</option>
+      </select>
+      <label class="muted" style="font-size:12px" title="Hace 1 request extra por canción">
+        <input type="checkbox" x-model="doceIncludeMeta" />
+        🎬 incluir metadatos (ritmo, álbum, YouTube, fiestas…)
+      </label>
+      <span class="count" x-text="filteredDoce().length + ' canciones'"></span>
+    </div>
+
+    <div x-show="doceLoading" class="muted" style="padding:10px">Cargando catálogo…</div>
+
+    <table class="songs">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Título</th>
+          <th>Autor</th>
+          <th>Subtítulo</th>
+          <th>En repo</th>
+          <th>Categoría destino</th>
+          <th>Nº</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="d in filteredDocePaged()" :key="d.id">
+          <tr :class="{ 'has-match': d.in_repo }">
+            <td style="font-family:monospace;font-size:11px" x-text="d.id"></td>
+            <td>
+              <a href="#" @click.prevent="previewDoce(d.id)" x-text="d.title"></a>
+            </td>
+            <td style="color:var(--fg-2);font-size:12px" x-text="d.artist"></td>
+            <td style="color:var(--fg-3);font-size:11px" x-text="d.subtitle"></td>
+            <td>
+              <template x-if="d.in_repo">
+                <a href="#" @click.prevent="openSongFromPath(d.repo_path)"
+                   class="badge-overwrite"
+                   x-text="'✓ ' + d.repo_category"></a>
+              </template>
+              <template x-if="!d.in_repo">
+                <span class="badge-new">nueva</span>
+              </template>
+            </td>
+            <td>
+              <select x-model="doceCategorySel[d.id]" class="cat-select-mini"
+                      @change="onDoceCategoryChange(d.id)">
+                <option value="">—</option>
+                <template x-for="cat in data.categories" :key="cat.letter">
+                  <option :value="cat.letter"
+                          x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '').slice(0,18)"></option>
+                </template>
+              </select>
+            </td>
+            <td>
+              <input type="number" min="1" max="99" style="width:50px"
+                     x-model.number="doceNumberSel[d.id]"
+                     :placeholder="doceSuggestedNumber[d.id] || '?'" />
+            </td>
+            <td style="white-space:nowrap">
+              <button class="btn-mini" @click="previewDoce(d.id)">👁 Ver</button>
+              <button class="btn-mini primary" :disabled="!doceCategorySel[d.id] || doceImporting"
+                      @click="importOneDoce(d.id)">📥 Importar</button>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+
+    <div class="filter-bar" x-show="filteredDoce().length > docePageSize">
+      <button @click="docePage = Math.max(0, docePage - 1)" :disabled="docePage === 0">← Anterior</button>
+      <span class="muted" x-text="'Página ' + (docePage + 1) + ' de ' + Math.ceil(filteredDoce().length / docePageSize)"></span>
+      <button @click="docePage = Math.min(Math.ceil(filteredDoce().length / docePageSize) - 1, docePage + 1)"
+              :disabled="(docePage + 1) * docePageSize >= filteredDoce().length">Siguiente →</button>
+    </div>
+
+    <div x-show="doceResults.length > 0" class="import-results" x-cloak>
+      <h3>Resultado:</h3>
+      <ul>
+        <template x-for="r in doceResults" :key="r.doce_id">
+          <li :class="{ ok: r.ok, err: !r.ok }">
+            <span x-text="r.ok ? '✓' : '✗'"></span>
+            <span x-text="'#' + r.doce_id + ' ' + (r.title || '')"></span>
+            <span x-show="r.path" class="path" x-text="r.path"></span>
+            <span x-show="r.error" class="error-msg" x-text="r.error"></span>
+          </li>
+        </template>
+      </ul>
+    </div>
+  </section>
+
+  <!-- DOCE PREVIEW MODAL -->
+  <div class="editor-overlay" x-show="docePreview" @click.self="docePreview = null" x-cloak>
+    <div class="editor-modal">
+      <div class="editor-header">
+        <h2>
+          🎸 <span x-text="docePreview ? docePreview.meta.title : ''"></span>
+          <span class="muted" style="font-size:13px;font-weight:normal"
+                x-text="docePreview ? ' — #' + docePreview.id : ''"></span>
+        </h2>
+        <div class="header-actions">
+          <select x-model="docePreviewCategory" style="margin-right:6px">
+            <option value="">— Categoría —</option>
+            <template x-for="cat in (data ? data.categories : [])" :key="cat.letter">
+              <option :value="cat.letter"
+                      x-text="cat.letter + '. ' + cat.title.replace(/^[A-Z+\d]+\.\s*/, '')"></option>
+            </template>
+          </select>
+          <button class="btn primary" :disabled="!docePreviewCategory || doceImporting"
+                  @click="importFromPreview()">📥 Importar</button>
+          <button class="btn" @click="reloadDocePreview()" :disabled="docePreviewReloading"
+                  title="Saltarse la caché local y volver a descargar"
+                  x-text="docePreviewReloading ? '⏳' : '↻ Re-descargar'"></button>
+          <a class="btn" :href="docePreview ? docePreview.entry.url : '#'" target="_blank">↗ Web</a>
+          <button class="btn" @click="docePreview = null">✕ Cerrar</button>
+        </div>
+      </div>
+      <div class="editor-body" x-show="docePreview">
+        <div class="editor-pane" style="overflow:auto">
+          <h4 style="margin:0 0 6px">.cho adaptado (estilo MCM)</h4>
+          <pre class="latex-preview" x-text="docePreview ? docePreview.content : ''"></pre>
+        </div>
+        <div class="editor-pane" style="overflow:auto;border-left:1px solid var(--border);padding:10px">
+          <h4 style="margin:0 0 6px">Datos básicos</h4>
+          <table class="meta-table" x-show="docePreview">
+            <tr><th>Título</th><td x-text="docePreview && docePreview.meta.title"></td></tr>
+            <tr><th>Artista</th><td x-text="docePreview && docePreview.meta.artist"></td></tr>
+            <tr><th>Tono</th><td x-text="docePreview && docePreview.meta.key"></td></tr>
+            <tr><th>Capo</th><td x-text="docePreview && (docePreview.meta.capo || '0')"></td></tr>
+            <tr x-show="docePreview && docePreview.entry.subtitle">
+              <th>Subtítulo</th><td x-text="docePreview && docePreview.entry.subtitle"></td>
+            </tr>
+          </table>
+
+          <template x-if="docePreview && hasExtras(docePreview.extras)">
+            <div>
+              <h4 style="margin:14px 0 6px">🎬 Multimedia & extras</h4>
+              <table class="meta-table">
+                <tr x-show="docePreview.extras.rhythm">
+                  <th>Ritmo</th><td x-text="docePreview.extras.rhythm"></td>
+                </tr>
+                <tr x-show="docePreview.extras.album">
+                  <th>Álbum</th><td x-text="docePreview.extras.album"></td>
+                </tr>
+                <tr x-show="docePreview.extras.liturgicalTime">
+                  <th>Tiempo</th><td x-text="docePreview.extras.liturgicalTime"></td>
+                </tr>
+                <tr x-show="docePreview.extras.source">
+                  <th>Fuente</th><td x-text="docePreview.extras.source"></td>
+                </tr>
+                <tr x-show="docePreview.extras.comment">
+                  <th>Comentario</th><td x-text="docePreview.extras.comment"></td>
+                </tr>
+                <tr x-show="docePreview.extras.videoEmbed">
+                  <th>Vídeo</th>
+                  <td><a :href="docePreview.extras.videoEmbed" target="_blank"
+                         class="link-url" x-text="docePreview.extras.videoEmbed"></a></td>
+                </tr>
+              </table>
+              <template x-if="docePreview.extras.youtubeLinks && docePreview.extras.youtubeLinks.length > 0">
+                <div style="margin-top:8px">
+                  <strong style="font-size:12px">📺 YouTube</strong>
+                  <ul class="link-list">
+                    <template x-for="(yt, i) in docePreview.extras.youtubeLinks" :key="'yt-'+i">
+                      <li>
+                        <span class="link-num" x-text="i+1"></span>
+                        <span class="link-label" x-text="yt.label || '(sin etiqueta)'"></span>
+                        <a :href="yt.url" target="_blank" class="link-url" x-text="yt.url"></a>
+                      </li>
+                    </template>
+                  </ul>
+                </div>
+              </template>
+              <template x-if="docePreview.extras.audioLinks && docePreview.extras.audioLinks.length > 0">
+                <div style="margin-top:8px">
+                  <strong style="font-size:12px">🎧 Audio</strong>
+                  <ul class="link-list">
+                    <template x-for="(au, i) in docePreview.extras.audioLinks" :key="'au-'+i">
+                      <li>
+                        <span class="link-num" x-text="i+1"></span>
+                        <span class="link-label" x-text="au.label || '(sin etiqueta)'"></span>
+                        <a :href="au.url" target="_blank" class="link-url" x-text="au.url"></a>
+                      </li>
+                    </template>
+                  </ul>
+                </div>
+              </template>
+            </div>
+          </template>
+          <div x-show="docePreview && !hasExtras(docePreview.extras)" class="muted" style="font-size:11px;margin-top:8px">
+            <span x-show="doceIncludeMeta">— Sin metadatos extras —</span>
+            <span x-show="!doceIncludeMeta">⚠ Importación rápida activa: los metadatos no se descargan.
+              <a href="#" @click.prevent="doceIncludeMeta = true; reloadDocePreview()">Activar y recargar →</a>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- LATEX PREVIEW MODAL -->
   <div class="editor-overlay" x-show="latexPreview" @click.self="latexPreview = null" x-cloak>
     <div class="editor-modal">
@@ -561,7 +892,13 @@
         <button :class="{active: editor.tab === 'visual'}" @click="setEditorTab('visual')">🎨 Visual</button>
         <button :class="{active: editor.tab === 'raw'}" @click="setEditorTab('raw')">📝 Raw</button>
         <button :class="{active: editor.tab === 'preview'}" @click="setEditorTab('preview')">👁 Preview</button>
+        <button :class="{active: editor.tab === 'media'}" @click="setEditorTab('media')">
+          🎬 Multimedia
+          <span class="tab-badge" x-show="(editor.meta.youtube_count || 0) + (editor.meta.audio_count || 0) > 0"
+                x-text="(editor.meta.youtube_count || 0) + (editor.meta.audio_count || 0)"></span>
+        </button>
         <span class="dirty" x-show="editor.dirty">● sin guardar</span>
+        <span class="dirty" x-show="mediaDirty" style="color:#0ea5e9">● multimedia sin guardar</span>
       </div>
 
       <div class="editor-body">
@@ -726,6 +1063,149 @@
         <!-- PREVIEW -->
         <div class="editor-pane preview" x-show="editor.tab === 'preview'" x-cloak>
           <div class="preview-render" x-html="renderPreviewHtml(editor.content)"></div>
+        </div>
+
+        <!-- MULTIMEDIA & META -->
+        <div class="editor-pane media-pane" x-show="editor.tab === 'media'" x-cloak>
+          <div class="media-toolbar">
+            <button class="btn primary" :disabled="!mediaDirty || mediaSaving"
+                    @click="saveMediaMeta()"
+                    x-text="mediaSaving ? 'Guardando…' : '💾 Guardar metadatos'"></button>
+            <button class="btn" :disabled="!mediaDirty" @click="resetMediaMeta()">Cancelar cambios</button>
+            <span class="muted" style="margin-left:auto;font-size:11px">
+              Estos datos NO aparecen en el chordpro que ve el cantor — solo en la ficha de la canción.
+            </span>
+          </div>
+
+          <div class="media-grid">
+            <div class="media-section">
+              <h4>📺 YouTube / Vídeo</h4>
+              <label>Vídeo principal (embed)</label>
+              <input type="url" x-model="mediaForm.videoEmbed" @input="mediaDirty = true"
+                     placeholder="https://www.youtube.com/embed/VIDEO_ID" />
+
+              <div class="link-list-editor">
+                <div class="link-list-header">
+                  <span>Links de YouTube (orden = prioridad)</span>
+                  <button class="btn-mini" @click="addMediaLink('youtubeLinks')">➕ Añadir</button>
+                </div>
+                <template x-for="(yt, i) in mediaForm.youtubeLinks" :key="'yt-'+i">
+                  <div class="link-row">
+                    <span class="link-num" x-text="i+1"></span>
+                    <input type="text" class="link-label-input" x-model="yt.label"
+                           @input="mediaDirty = true" placeholder="Etiqueta (ej: Original)" />
+                    <input type="url" class="link-url-input" x-model="yt.url"
+                           @input="mediaDirty = true" placeholder="https://www.youtube.com/watch?v=…" />
+                    <div class="link-actions">
+                      <button class="btn-mini" :disabled="i === 0"
+                              @click="moveMediaLink('youtubeLinks', i, -1)">↑</button>
+                      <button class="btn-mini" :disabled="i === mediaForm.youtubeLinks.length - 1"
+                              @click="moveMediaLink('youtubeLinks', i, 1)">↓</button>
+                      <button class="btn-mini danger" @click="removeMediaLink('youtubeLinks', i)">✕</button>
+                    </div>
+                  </div>
+                </template>
+                <div class="muted" x-show="mediaForm.youtubeLinks.length === 0"
+                     style="font-size:12px;padding:6px">— Sin links de YouTube —</div>
+              </div>
+            </div>
+
+            <div class="media-section">
+              <h4>🎧 Audio interno</h4>
+              <p class="muted" style="font-size:11px;margin-top:0">
+                Grabaciones nuestras (ensayos, versión coro…). URLs a Drive, dropbox, S3, etc.
+              </p>
+              <div class="link-list-editor">
+                <div class="link-list-header">
+                  <span>Audios (orden = prioridad)</span>
+                  <button class="btn-mini" @click="addMediaLink('audioLinks')">➕ Añadir</button>
+                </div>
+                <template x-for="(au, i) in mediaForm.audioLinks" :key="'au-'+i">
+                  <div class="link-row">
+                    <span class="link-num" x-text="i+1"></span>
+                    <input type="text" class="link-label-input" x-model="au.label"
+                           @input="mediaDirty = true" placeholder="Etiqueta (ej: Ensayo voces)" />
+                    <input type="url" class="link-url-input" x-model="au.url"
+                           @input="mediaDirty = true" placeholder="https://…/audio.mp3" />
+                    <div class="link-actions">
+                      <button class="btn-mini" :disabled="i === 0"
+                              @click="moveMediaLink('audioLinks', i, -1)">↑</button>
+                      <button class="btn-mini" :disabled="i === mediaForm.audioLinks.length - 1"
+                              @click="moveMediaLink('audioLinks', i, 1)">↓</button>
+                      <button class="btn-mini danger" @click="removeMediaLink('audioLinks', i)">✕</button>
+                    </div>
+                  </div>
+                </template>
+                <div class="muted" x-show="mediaForm.audioLinks.length === 0"
+                     style="font-size:12px;padding:6px">— Sin audios internos —</div>
+              </div>
+            </div>
+
+            <div class="media-section">
+              <h4>📝 Datos extra</h4>
+              <label>Ritmo</label>
+              <input type="text" x-model="mediaForm.rhythm" @input="mediaDirty = true"
+                     placeholder="parones+rasgueo, balada 6/8…" />
+              <label>Álbum</label>
+              <input type="text" x-model="mediaForm.album" @input="mediaDirty = true"
+                     placeholder="Capricho, 2023" />
+              <label>Tiempo litúrgico / Fiestas</label>
+              <input type="text" x-model="mediaForm.liturgicalTime" @input="mediaDirty = true"
+                     placeholder="Semana Santa | Vigilia Pascual" />
+              <label>Fuente</label>
+              <input type="text" x-model="mediaForm.source" @input="mediaDirty = true"
+                     placeholder="doceacordes.es - Parroquia San Bruno" />
+              <label>Comentario</label>
+              <textarea rows="2" x-model="mediaForm.comment" @input="mediaDirty = true"
+                        placeholder="María Magdalena, Versión Hakuna…"></textarea>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- QUICK ADD LINK MODAL -->
+  <div class="editor-overlay" x-show="quickLink.open" @click.self="quickLink.open = false" x-cloak>
+    <div class="editor-modal small">
+      <div class="editor-header">
+        <h2>
+          <span x-text="quickLink.type === 'youtube' ? '📺 Añadir YouTube' : '🎧 Añadir Audio'"></span>
+          <span class="muted" style="font-size:13px;font-weight:normal"
+                x-text="quickLink.songTitle ? '— ' + quickLink.songTitle : ''"></span>
+        </h2>
+        <button class="btn" @click="quickLink.open = false">✕ Cerrar</button>
+      </div>
+      <div class="editor-body single">
+        <div class="editor-pane" style="overflow:auto">
+          <!-- Lista de links existentes -->
+          <div x-show="quickLink.existing.length > 0" style="margin-bottom:14px">
+            <h4 style="margin:0 0 6px;font-size:12px;color:var(--fg-3)">Existentes</h4>
+            <ul class="link-list">
+              <template x-for="(lk, i) in quickLink.existing" :key="i">
+                <li>
+                  <span class="link-num" x-text="i+1"></span>
+                  <span class="link-label" x-text="lk.label || '(sin etiqueta)'"></span>
+                  <a :href="lk.url" target="_blank" class="link-url" x-text="lk.url"></a>
+                  <button class="btn-mini danger" @click="removeQuickLink(i)">✕</button>
+                </li>
+              </template>
+            </ul>
+          </div>
+          <div class="form-grid">
+            <label>Etiqueta</label>
+            <input type="text" x-model="quickLink.label"
+                   :placeholder="quickLink.type === 'youtube' ? 'Original, Alternativo, En vivo…' : 'Ensayo voces, Versión coro…'" />
+            <label>URL</label>
+            <input type="url" x-model="quickLink.url"
+                   :placeholder="quickLink.type === 'youtube' ? 'https://www.youtube.com/watch?v=…' : 'https://drive.google.com/… o /audio.mp3'" />
+          </div>
+          <div class="actions-row">
+            <button class="btn primary" :disabled="!quickLink.url || quickLink.saving"
+                    @click="saveQuickAddLink()"
+                    x-text="quickLink.saving ? 'Guardando…' : 'Añadir y guardar'"></button>
+            <button class="btn" @click="openMultimediaTab(quickLink.path)">Editar todo →</button>
+          </div>
         </div>
       </div>
     </div>

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -323,6 +323,40 @@ table.songs tr.has-doce td { background: rgba(234, 88, 12, 0.08); }
   background: var(--bg-2); padding: 0 4px; border-radius: 3px;
 }
 .doce-cand-sub { font-size: 11px; color: var(--fg-3); margin-top: 2px; padding-left: 32px; }
+
+/* ─────── Reorder gaps ─────── */
+.reorder-row-main { display: inline-flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
+.reorder-row-main .link-mini { margin-left: auto; opacity: 0; transition: opacity 0.1s; }
+.reorder-list li:hover .reorder-row-main .link-mini { opacity: 1; }
+.reorder-gap {
+  background: repeating-linear-gradient(
+    -45deg, transparent, transparent 6px,
+    rgba(0,0,0,0.04) 6px, rgba(0,0,0,0.04) 12px
+  ) !important;
+  color: var(--fg-3);
+  border-left: 3px solid rgba(0,0,0,0.10);
+}
+.theme-dark .reorder-gap {
+  background: repeating-linear-gradient(
+    -45deg, transparent, transparent 6px,
+    rgba(255,255,255,0.04) 6px, rgba(255,255,255,0.04) 12px
+  ) !important;
+  border-left-color: rgba(255,255,255,0.10);
+}
+.reorder-gap .new-num { background: var(--fg-3) !important; }
+.reorder-gap .reorder-row-main .link-mini { opacity: 1; }
+.gap-label { font-style: italic; font-size: 12px; color: var(--fg-3); }
+
+/* ─────── Editor queue progress ─────── */
+.queue-progress {
+  display: inline-flex; align-items: center; gap: 8px;
+  margin-right: 12px; padding: 4px 10px;
+  background: rgba(14, 165, 233, 0.12); color: #0369a1;
+  border: 1px solid rgba(14, 165, 233, 0.30); border-radius: 4px;
+  font-size: 12px;
+}
+.theme-dark .queue-progress { color: #7dd3fc; }
+.queue-progress strong { font-weight: 700; }
 .badge-overwrite {
   display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
   background: rgba(202, 138, 4, 0.18); color: var(--warn); border: 1px solid rgba(202, 138, 4, 0.4);
@@ -505,7 +539,8 @@ table.songs tr.has-doce td { background: rgba(234, 88, 12, 0.08); }
 .ed-marker .link-mini { background: none; border: none; color: inherit; cursor: pointer; font-size: 11px; opacity: 0.6; }
 .ed-marker .link-mini:hover { opacity: 1; color: var(--danger); }
 
-.ed-line-row { position: relative; margin: 18px 0 2px; min-height: 1.4em; padding-left: 28px; }
+.ed-line.ed-lyric { padding-top: 18px; padding-bottom: 2px; }
+.ed-line-row { position: relative; margin: 0; min-height: 1.4em; padding-left: 28px; }
 .ed-chords-layer { position: absolute; top: -1.05em; left: 28px; right: 0; height: 1.1em; pointer-events: none; }
 .ed-lyric-row { white-space: pre; font-size: 15px; line-height: 1.25; }
 .ed-char {
@@ -526,9 +561,9 @@ table.songs tr.has-doce td { background: rgba(234, 88, 12, 0.08); }
 .ed-line.selected .line-gutter { color: var(--accent); opacity: 1; font-weight: bold; }
 .ed-line.selected .ed-lyric-row { background: rgba(37, 99, 235, 0.08); }
 .theme-dark .ed-line.selected .ed-lyric-row { background: rgba(59, 130, 246, 0.18); }
-.ed-line.ed-soc + .ed-line.ed-lyric .ed-line-row,
-.ed-line.ed-lyric + .ed-line.ed-lyric .ed-line-row {
-  margin-top: 10px;
+.ed-line.ed-soc + .ed-line.ed-lyric,
+.ed-line.ed-lyric + .ed-line.ed-lyric {
+  padding-top: 10px;
 }
 .ed-line.ed-lyric.in-chorus .ed-lyric-row { background-image: linear-gradient(to right, rgba(202, 138, 4, 0.06), transparent 30%); }
 .theme-dark .ed-line.ed-lyric.in-chorus .ed-lyric-row { background-image: linear-gradient(to right, rgba(234, 179, 8, 0.12), transparent 30%); }

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -184,6 +184,145 @@ table.songs tr.has-match td { background: rgba(139, 92, 246, 0.06); }
 }
 .badge-latex:hover { background: rgba(139, 92, 246, 0.30); }
 .theme-dark .badge-latex { color: #c4b5fd; }
+.badge-latex-mini {
+  display: inline-block; margin-left: 6px; padding: 0 4px; font-size: 9px;
+  background: rgba(139, 92, 246, 0.10); color: #6d28d9; border-radius: 2px; cursor: pointer;
+}
+.theme-dark .badge-latex-mini { color: #c4b5fd; }
+
+/* ─────── Importar doceacordes (prioridad alta) ─────── */
+.badge-doce {
+  display: inline-block; margin-left: 8px; padding: 2px 8px; font-size: 11px;
+  background: rgba(234, 88, 12, 0.20); color: #c2410c; border-radius: 3px;
+  cursor: pointer; border: 1px solid rgba(234, 88, 12, 0.45); font-weight: 700;
+}
+.badge-doce:hover { background: rgba(234, 88, 12, 0.35); }
+.theme-dark .badge-doce { color: #fdba74; }
+table.songs tr.has-doce td { background: rgba(234, 88, 12, 0.08); }
+.theme-dark table.songs tr.has-doce td { background: rgba(234, 88, 12, 0.16); }
+
+/* ─────── Multimedia (catálogo + editor) ─────── */
+.media-cell { white-space: nowrap; }
+.media-icon {
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 2px 6px; margin-right: 4px; font-size: 13px;
+  background: transparent; border: 1px solid var(--border); border-radius: 4px;
+  cursor: pointer; opacity: 0.4; transition: opacity 0.15s, background 0.15s;
+}
+.media-icon:hover { opacity: 1; background: var(--bg-2); }
+.media-icon.active { opacity: 1; background: rgba(14, 165, 233, 0.10); border-color: rgba(14, 165, 233, 0.35); }
+.media-icon .media-count {
+  font-size: 10px; font-weight: 700; color: var(--fg-2);
+  background: var(--bg-2); padding: 0 4px; border-radius: 8px; margin-left: 2px;
+}
+.tab-badge {
+  display: inline-block; min-width: 16px; height: 16px; padding: 0 4px;
+  margin-left: 4px; font-size: 10px; font-weight: 700; line-height: 16px;
+  background: rgba(14, 165, 233, 0.2); color: #0369a1; border-radius: 8px;
+  text-align: center;
+}
+.theme-dark .tab-badge { color: #7dd3fc; }
+
+.media-pane { padding: 0; overflow: auto; }
+.media-toolbar {
+  display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+  border-bottom: 1px solid var(--border); background: var(--bg-2); position: sticky; top: 0; z-index: 1;
+}
+.media-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 18px; padding: 16px;
+}
+.media-section {
+  background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 12px;
+}
+.media-section:nth-child(3) { grid-column: 1 / -1; }
+.media-section h4 { margin: 0 0 10px; font-size: 14px; }
+.media-section label { display: block; font-size: 11px; color: var(--fg-3);
+  margin: 8px 0 3px; font-weight: 600; }
+.media-section input[type="text"], .media-section input[type="url"], .media-section textarea {
+  width: 100%; padding: 5px 7px; font-size: 13px;
+  background: var(--bg); border: 1px solid var(--border-strong); border-radius: 3px; color: var(--fg);
+}
+.link-list-editor { margin-top: 10px; }
+.link-list-header {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; font-weight: 600; color: var(--fg-3); margin-bottom: 4px;
+}
+.link-row {
+  display: grid; grid-template-columns: 24px 130px 1fr auto;
+  gap: 4px; align-items: center; padding: 4px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.link-num {
+  display: inline-block; width: 22px; height: 22px; line-height: 22px; text-align: center;
+  background: var(--accent); color: white; border-radius: 3px; font-size: 11px; font-weight: 700;
+}
+.link-label-input { font-size: 12px !important; }
+.link-url-input { font-size: 11px !important; font-family: monospace; }
+.link-actions { display: flex; gap: 2px; }
+.link-actions .btn-mini { padding: 2px 5px; font-size: 11px; min-width: 22px; }
+
+/* Quick-add modal lista existentes */
+.link-list { list-style: none; margin: 0; padding: 0; }
+.link-list li {
+  display: grid; grid-template-columns: 24px 130px 1fr auto; gap: 6px; align-items: center;
+  padding: 4px 0; border-bottom: 1px dashed var(--border); font-size: 12px;
+}
+.link-list .link-url {
+  color: var(--accent); text-decoration: none; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; font-family: monospace; font-size: 11px;
+}
+.link-list .link-url:hover { text-decoration: underline; }
+.link-list .link-label { font-weight: 600; }
+
+/* ─────── Dashboard groups ─────── */
+.stats-group { margin-bottom: 18px; }
+.stats-group-title {
+  font-size: 12px; font-weight: 700; color: var(--fg-3);
+  text-transform: uppercase; letter-spacing: 0.5px;
+  margin: 0 0 8px 2px; padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ─────── Meta table (preview modals) ─────── */
+.meta-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.meta-table th {
+  text-align: left; font-weight: 600; color: var(--fg-3);
+  padding: 3px 6px 3px 0; vertical-align: top; width: 80px; white-space: nowrap;
+}
+.meta-table td { padding: 3px 0; vertical-align: top; word-break: break-word; }
+
+/* ─────── Doceacordes candidates popover ─────── */
+.badge-doce-wrap { position: relative; display: inline-block; }
+.doce-popover {
+  position: absolute; top: 100%; left: 0; z-index: 100;
+  margin-top: 4px; min-width: 320px; max-width: 480px;
+  background: var(--bg); border: 1px solid rgba(234, 88, 12, 0.45);
+  border-radius: 6px; box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+  padding: 6px;
+}
+.theme-dark .doce-popover { box-shadow: 0 8px 24px rgba(0,0,0,0.5); }
+.doce-popover-head {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 11px; font-weight: 700; color: var(--fg-2);
+  padding: 4px 6px 6px; border-bottom: 1px solid var(--border); margin-bottom: 4px;
+}
+.doce-cand {
+  padding: 6px 8px; border-radius: 4px; cursor: pointer;
+  transition: background 0.1s;
+}
+.doce-cand:hover { background: rgba(234, 88, 12, 0.10); }
+.doce-cand-main { display: flex; align-items: baseline; gap: 6px; }
+.doce-cand-num {
+  font-family: monospace; font-size: 10px; padding: 1px 5px;
+  background: rgba(234, 88, 12, 0.18); color: #c2410c; border-radius: 3px; font-weight: 700;
+}
+.theme-dark .doce-cand-num { color: #fdba74; }
+.doce-cand-title { font-weight: 600; flex: 1; font-size: 13px; }
+.doce-cand-score {
+  font-size: 10px; color: var(--fg-3); font-family: monospace;
+  background: var(--bg-2); padding: 0 4px; border-radius: 3px;
+}
+.doce-cand-sub { font-size: 11px; color: var(--fg-3); margin-top: 2px; padding-left: 32px; }
 .badge-overwrite {
   display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
   background: rgba(202, 138, 4, 0.18); color: var(--warn); border: 1px solid rgba(202, 138, 4, 0.4);

--- a/scripts/crear_songs_json.py
+++ b/scripts/crear_songs_json.py
@@ -52,6 +52,64 @@ def parse_metadata(text):
     meta['capo'] = int(capo.group(1)) if capo and capo.group(1).isdigit() else 0
     return meta
 
+
+# Custom directives MCM que NO son parte del cuerpo ChordPro. Se extraen a
+# campos JSON y se eliminan del `content` para que el renderer móvil no
+# las imprima como comentarios visibles.
+CUSTOM_META_KEYS = ('ritmo', 'album', 'tiempo', 'fuente', 'video',
+                    'youtube', 'audio', 'comentario')
+
+
+def _parse_label_url(value):
+    """Convierte 'Label | https://url' en {label, url}. Si no hay '|', label='' y url=value."""
+    if '|' in value:
+        label, _, url = value.partition('|')
+        return {'label': label.strip(), 'url': url.strip()}
+    return {'label': '', 'url': value.strip()}
+
+
+def parse_custom_meta(text):
+    """Extrae las custom directives MCM. Devuelve dict con campos JSON-friendly."""
+    extra = {
+        'rhythm': '',
+        'album': '',
+        'liturgicalTime': '',
+        'source': '',
+        'videoEmbed': '',
+        'youtubeLinks': [],
+        'audioLinks': [],
+        'comment': '',
+    }
+    for m in re.finditer(r'\{\s*(ritmo|album|tiempo|fuente|video|youtube|audio|comentario)\s*:\s*(.*?)\s*\}',
+                         text, re.IGNORECASE):
+        key = m.group(1).lower()
+        val = m.group(2).strip()
+        if not val:
+            continue
+        if key == 'ritmo':
+            extra['rhythm'] = val
+        elif key == 'album':
+            extra['album'] = val
+        elif key == 'tiempo':
+            extra['liturgicalTime'] = val
+        elif key == 'fuente':
+            extra['source'] = val
+        elif key == 'video':
+            extra['videoEmbed'] = val
+        elif key == 'comentario':
+            extra['comment'] = val
+        elif key == 'youtube':
+            extra['youtubeLinks'].append(_parse_label_url(val))
+        elif key == 'audio':
+            extra['audioLinks'].append(_parse_label_url(val))
+    return extra
+
+
+def strip_custom_meta_from_content(text):
+    """Elimina las líneas de custom directives MCM del contenido."""
+    pattern = r'^[ \t]*\{\s*(?:' + '|'.join(CUSTOM_META_KEYS) + r')\s*:[^}]*\}[ \t]*\r?\n?'
+    return re.sub(pattern, '', text, flags=re.IGNORECASE | re.MULTILINE)
+
 # Función principal
 def main():
     # Directorio donde está este script
@@ -104,6 +162,8 @@ def main():
             path = os.path.join(cat_path, fname)
             text = open(path, encoding='utf-8').read()
             meta = parse_metadata(text)  # Extrae metadatos
+            extra = parse_custom_meta(text)  # Multimedia + meta extra
+            clean_content = strip_custom_meta_from_content(text)
 
             # Extrae código numérico inicial, ej. "01" → "01. "
             code = ''
@@ -119,8 +179,17 @@ def main():
                 'key':      meta['key'],
                 'capo':     meta['capo'],
                 'info':     '',
-                'content':  text  # Contenido completo con saltos de línea
+                'content':  clean_content  # Cuerpo sin custom meta directives
             }
+            # Emitir campos extra solo si tienen valor (evita inflar el JSON)
+            if extra['rhythm']:         entry['rhythm'] = extra['rhythm']
+            if extra['album']:          entry['album'] = extra['album']
+            if extra['liturgicalTime']: entry['liturgicalTime'] = extra['liturgicalTime']
+            if extra['source']:         entry['source'] = extra['source']
+            if extra['videoEmbed']:     entry['videoEmbed'] = extra['videoEmbed']
+            if extra['youtubeLinks']:   entry['youtubeLinks'] = extra['youtubeLinks']
+            if extra['audioLinks']:     entry['audioLinks'] = extra['audioLinks']
+            if extra['comment']:        entry['comment'] = extra['comment']
             print(f"   🎵 {fname} -> {entry['title']} (Key={entry['key']}, Capo={entry['capo']})")
             songs.append(entry)
 

--- a/songs-backup-edits/20260524-140941/A. Entrada/08.vivire_alabandote.cho
+++ b/songs-backup-edits/20260524-140941/A. Entrada/08.vivire_alabandote.cho
@@ -1,0 +1,10 @@
+{title: Viviré Alabándote}
+{artist: Maite López}
+{key: G}
+
+{soc}
+[G]Viviré alabánd[D]ote, adoránd[C]ote y sirviénd[G]ote
+[Em]toda mi cap[Bm]acidad de amar [C]es para ti (b[D]is)
+{eoc}
+[Am]Todo lo que tengo es [D]tuyo, [Am]en todo puedo encontrar[D]te
+[B7]haz que sepa utilizar[C]lo, solo [G]si me ayuda amar[D]te.

--- a/songs-backup-edits/20260524-141258/A. Entrada/09.aclamad_cielos.cho
+++ b/songs-backup-edits/20260524-141258/A. Entrada/09.aclamad_cielos.cho
@@ -1,0 +1,12 @@
+{title: Aclamad Cielos}
+{key: D}
+
+
+{soc}
+ACLAM[D]AD CIELOS, EXULTA [Bm]TIERRA
+PORQUE Y[Em]AVEH HA CONSOLADO A S[A]U PUEBLO	[D]
+Y DE SUS POBRES SE [Bm]HA COMPA[Em]DECI[A]DO[D]
+{eoc}
+
+[D]En tiempo fav[Bm]orable te escucho, [Em]yo te formé[A][D]
+Y t[Bm]e he desti[D]nado a [G]ser alianza de un p[A]ueblo, d[D]ice el Señ[A]or.

--- a/songs-backup-edits/20260524-141403/A. Entrada/09.aclamad_cielos.cho
+++ b/songs-backup-edits/20260524-141403/A. Entrada/09.aclamad_cielos.cho
@@ -10,9 +10,3 @@ Y DE SUS [Bm]POBRES SE [Em]HA [A]COMPADECI[D]DO
 
 [D]En tiempo fav[Bm]orable te es[Em]cucho, [A]yo te for[D]mé
 Y t[Bm]e he desti[D]nado a [G]ser alianza de un p[A]ueblo, dice el Se[D]ñor.  [A]   
-
-{soc}
-ACLAM[D]AD CIELOS, EXULTA [Bm]TIERRA     [D] 
-PORQUE Y[Em]AVEH HA CONSO[A]LADO A SU [d]PUEBLO	
-Y DE SUS [Bm]POBRES SE [Em]HA [A]COMPADECI[D]DO
-{eoc}

--- a/songs-backup-edits/20260524-160221/A. Entrada/01.ven_a_celebrar.cho
+++ b/songs-backup-edits/20260524-160221/A. Entrada/01.ven_a_celebrar.cho
@@ -1,0 +1,16 @@
+{title: Ven a Celebrar}
+{artist: Alborada}
+{key: G}
+{youtube: TEST_AUTOMATIZADO | https://www.youtube.com/watch?v=TEST}
+
+{soc}
+[G]VEN A CELEBRAR EL AM[bm]OR DE DIOS, [C]SE DERRAMARÁ COMO [G]AGUA LIMPIA  
+[C]  INUNDANDO NUESTRAS [G]VIDAS DE [C]SU PRESENC[D]IA (bis)
+{eoc}
+
+[Em]  Os aseguro que [Bm]yo estaré [C] cuando dos o más por [G]mí os reunáis.  
+[C]  Es la mejor forma [G]de crecer en [C]nuestra amistad, en [D]nuestra amistad...
+
+Nos has traído al desierto para hablarnos al corazón 
+y transformar nuestras vidas con tus palabras de amor, palabras de amor...
+

--- a/songs-backup-edits/20260524-174239/A. Entrada/12.surgira_mundo_nuevo.cho
+++ b/songs-backup-edits/20260524-174239/A. Entrada/12.surgira_mundo_nuevo.cho
@@ -1,0 +1,16 @@
+{title: Surgirá un Mundo Nuevo}
+{artist: Verbum Dei}
+{key: C}
+{capo: 2}
+
+
+{soc}
+SURGI[C]RÁ UN MUNDO NUEVO LEVAN[G]TADO POR LA FUERZA DEL A[C]MOR 
+HECHO POR HOMBRES CON EL CORAZON [G]ABIERTO AL ESPIRITU DE  [C]DIOS
+Y SU [F]LEY SERA EL PERDON Y SU JUST[Am]ICIA EL AMOR,
+POR LA [F]FUERZA DE SU [G]FE EN EL SE[C]ÑOR.
+{eoc}
+
+[C]Un solo Dios nos re[G]úne en su paz, 
+derri[F]bando las murallas con que [G]fuimos separados. 
+Un s[C]olo bautismo una [G]misma fe, por su [F]cruz Él ha vencido a la muerte,  ha c[Dm]reado en si [G]mismo un hombre [C]nuevo[G]...

--- a/songs/A. Entrada/02.dios_esta_aqui.cho
+++ b/songs/A. Entrada/02.dios_esta_aqui.cho
@@ -2,6 +2,7 @@
 {title: Dios Está Aquí}
 {key: C}
 {capo: 1}
+{artist: Javier Gacías Mateo (Grupo Mojado)}
 
 {soc}
 [C]DIOS ES[G]TÁ AQ[Am]UÍ TAN [F]CIERTO COMO EL AIRE [G]QUE RES[C]PIRO [C7] 
@@ -9,7 +10,18 @@ TAN [F]CIERTO COMO LA MA[G]ÑANA SE LE[C]VAAA[Em]AAAAN[Am]TA
 TAN [F]CIERTO COMO QUE ESTE [G]CANTO LO PUEDES [C]OÍR  
 {eoc}
 
+{c: Estrofa 1}
 LO PUEDES SEN[G]TIR MO[F]VIÉNDOSE ENTRE LOS QUE [C]AMAN  
 LO PUEDES [G]OÍR CAN[F]TANDO CON NOSOTROS AQU[C]Í  
 LO PUEDES LLE[G]VAR CUAN[F]DO POR ESA PUERTA [C]SALGAS  
 LO PUEDES GUAR[G]DAR POR SI[F]EMPRE EN TU [G]CORA[C]ZÓN [G7]    
+
+{c: Estrofa 2}
+[C]Lo puedes no[G]tar
+jun[F]to a ti en cual[G]quier mo[C]mento; 
+le puedes ha[G]blar
+de e[F]sa vida que le [G]quieres [C]dar;  
+no temas ya [G]más,
+Él es [F]Dios y nos per[G]dona a [C]todos; 
+Jesús está a[G]quí,
+si [F]tú quieres le pue[G]des se[C]guir.

--- a/songs/A. Entrada/08.vivire_alabandote.cho
+++ b/songs/A. Entrada/08.vivire_alabandote.cho
@@ -6,5 +6,10 @@
 [G]Viviré alabánd[D]ote, adoránd[C]ote y sirviénd[G]ote
 [Em]toda mi cap[Bm]acidad de amar [C]es para ti (b[D]is)
 {eoc}
-[Am]Todo lo que tengo es [D]tuyo, [Am]en todo puedo encontrar[D]te
-[B7]haz que sepa utilizar[C]lo, solo [G]si me ayuda amar[D]te.
+[Am]  Todo lo que tengo es [D]tuyo, [Am]  en todo puedo encon[D]trarte
+[B7]  haz que sepa utili[C]zarlo, [G]  solo si me ayuda a[D]marte.
+
+{soc}
+[G]Viviré alabánd[D]ote, adoránd[C]ote y sirviénd[G]ote
+[Em]toda mi cap[Bm]acidad de amar [C]es para ti (b[D]is)
+{eoc}

--- a/songs/A. Entrada/12.surgira_mundo_nuevo.cho
+++ b/songs/A. Entrada/12.surgira_mundo_nuevo.cho
@@ -11,6 +11,16 @@ Y SU [F]LEY SERA EL PERDON Y SU JUST[Am]ICIA EL AMOR,
 POR LA [F]FUERZA DE SU [G]FE EN EL SE[C]ÑOR.
 {eoc}
 
+{c: Estrofa 1}
 [C]Un solo Dios nos re[G]úne en su paz, 
-derri[F]bando las murallas con que [G]fuimos separados. 
-Un s[C]olo bautismo una [G]misma fe, por su [F]cruz Él ha vencido a la muerte,  ha c[Dm]reado en si [G]mismo un hombre [C]nuevo[G]...
+derri[F]bando las murallas con que [Dm]fuimos sepa[G7]rados. 
+Un s[C]olo bautismo una [G]misma fe, 
+por su [Am]cruz Él ha vencido a la [F]muerte,  
+ha c[Dm]reado en si [G7]mismo un hombre [C]nuevo..[G]. 
+
+{c: Estrofa 2}
+[C]Gentes de toda [G]raza, lengua y nación,
+forma[F]remos este pueblo dedi[Dm]cado al Se[G7]ñor:
+sin es[C]clavo ni libre, hombre ni [F]mujer.
+Uno [Am]sólo es el Señor y Él nos [F]une.
+Canta[Dm]remos las gran[G7]dezas del Dios [C]vivo..[G7].

--- a/songs/A. Entrada/22.yo_celebrare.cho
+++ b/songs/A. Entrada/22.yo_celebrare.cho
@@ -1,0 +1,37 @@
+{comment: TO DO: PENDIENTE REVISIÓN ACORDES}
+{title: Yo celebraré}
+{artist: Linda Duval}
+{capo: 3}
+{key: Am}
+{ritmo: parón + 4x4}
+{tiempo: Ordinario | Misa de familias | Entrada}
+{fuente: doceacordes.es - Parroquia San Bruno}
+{video: https://www.youtube.com/embed/z-LO96r77_Q}
+{youtube: Alternativo | https://www.youtube.com/watch?v=N5a9tW1aok8}
+{comentario: Salmo 68. Salmo 31}
+
+{soc}
+1ª vez:
+{eoc}
+*Todos*:
+{soc}
+([Am]Yo celebraré (palmas,) [F]delante del Señor (palmas),
+[G]cantaré un canto [Am]nuevo.) (Bis)
+{eoc}
+*Todos*:	
+([Am]Yo le [F]alabaré porque [G]Él ha hecho [Am]grandes cosas.) (Bis)
+
+{soc}
+2ª vez:
+{eoc}
+*A la vez, solapando chicos y chicas*:
+-Chicos:
+{soc}
+([Am]Yo celebraré (palmas), [F]delante del Señor (palmas),
+[G]cantaré un canto [Am]nuevo.) (Bis)
+{eoc}
+-Chicas:
+(Yo le alabaré porque Él ha hecho grandes cosas.)(Bis)
+
+NOTA:
+Posibilidad de terminar en una 3ª vez, añadiendo sin bis, el estribillo (cantado por todos)


### PR DESCRIPTION
## Summary

- **Nuevo importador** desde [doceacordes.es](https://doceacordes.es) (~1.700 canciones en ChordPro). Descarga, adapta al estilo MCM (`{soc}`/`{eoc}`, acordes ES→EN) y, opcionalmente, scrape de metadatos (ritmo, álbum, parroquia, vídeo, links de YouTube).
- **Soporte multimedia** en cada canción: nuevas custom directives `{ritmo}`, `{album}`, `{tiempo}`, `{fuente}`, `{video}`, `{youtube}` (repetible), `{audio}` (repetible), `{comentario}`. Se extraen a campos JSON propios y se eliminan del `content` que renderiza la app móvil.
- **UI del admin** ampliada: nueva vista de importación, badge prioritario 🎸 con popover de candidatos en el importer del cantoral, columna multimedia + minimodal "Quick-add link" en el catálogo, tab 🎬 Multimedia en el editor con listas reordenables.

## Cambios principales

### Backend
- `scripts/admin/doceacordes_import.py` (nuevo): fetch + adapt + scraping + matching difuso (Jaccard) con `scripts/canciones_doce_acordes.json`.
- `scripts/admin/server.py`: endpoints `/api/doce/{list,preview,suggest-number,import}`, `PUT /api/song/meta`, `POST /api/song/meta/quick-add`. Sanitización de `}`, `|`, `\n`.
- `scripts/crear_songs_json.py`: parsea y emite campos nuevos (`rhythm`, `album`, `liturgicalTime`, `source`, `videoEmbed`, `youtubeLinks`, `audioLinks`, `comment`); limpia `content`.

### Frontend admin
- Vista nueva **🎸 Importar de doceacordes.es** con preview side-by-side, metadatos extras como tabla + listas de links, botón **↻ Re-descargar** para saltar caché.
- **Popover de candidatos** en el importer del cantoral cuando hay >1 match.
- **Columna 📺/🎧** en el catálogo con contadores, click → minimodal Quick-add link.
- **Tab 🎬 Multimedia** en el editor (YouTube / Audio / Datos extra). Guardado independiente del cuerpo.
- **Dashboard reorganizado** en 4 secciones (Catálogo / Pendiente / Fuentes / Multimedia).
- Protecciones: avisa si guardas meta con cuerpo dirty; avisa si dejas el tab Multimedia con cambios.

### Docs
- `README.md`: tabla de los 8 campos nuevos del JSON con su directive y tipo.

## Test plan

- [ ] Arrancar `scripts/admin/server.py` y abrir el admin.
- [ ] Ir a **🎸 Importar de doceacordes**: buscar una canción, abrir preview, comprobar que se ve el `.cho` adaptado y la tabla de metadatos extras.
- [ ] Importar una canción con `include_meta=ON` → comprobar que el `.cho` resultante incluye `{ritmo}`, `{video}`, `{youtube}` etc.
- [ ] Importar con `include_meta=OFF` → comprobar que NO incluye esas directives.
- [ ] En el catálogo, click en el icono 📺 de una canción → añadir un link de YouTube → comprobar que aparece el contador.
- [ ] Abrir el editor de esa canción → tab 🎬 Multimedia → comprobar que aparece el link y se puede reordenar/borrar.
- [ ] Editar el cuerpo (raw) + ir al tab Multimedia + guardar meta → debe avisar de cambios sin guardar.
- [ ] Ir a **Importar del cantoral**, buscar una canción con badge 🎸 con varios candidatos → click → popover con los candidatos.
- [ ] Ejecutar `python scripts/crear_songs_json.py` y comprobar que el JSON resultante incluye los nuevos campos cuando existen.

## Notas para el reviewer

- El cache de descargas se guarda en `scripts/cache_doceacordes/` (ignorado por git).
- El front móvil (`mcmapp/mcm-app`) **aún no consume** los nuevos campos JSON — eso queda para otra PR en ese repo.
- Incluye dos ediciones manuales de letras (`songs/A. Entrada/08`, `09`) hechas durante la sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)