### PR TITLE
feat(admin): consultar y guardar peticiones de la gente desde Firebase

### DIFF
--- a/peticiones/README.md
+++ b/peticiones/README.md
@@ -24,13 +24,25 @@ Al pulsar **Consultar y guardar**:
    resolvieron se conservan marcadas con `_inFirebase: false`).
 3. Guarda el resultado en `peticiones.json`.
 
-Para conservar el histórico en el repo, haz commit del archivo:
+Para conservar el histórico en el repo puedes pulsar **📦 Guardar en el repo
+(commit)**, que hace `git add/commit/push` solo de esta carpeta, o hacerlo a mano:
 
 ```bash
 git add peticiones/peticiones.json
 git commit -m "chore: actualizar peticiones de la gente"
 git push
 ```
+
+## ¿Hacen falta variables de Firebase?
+
+No hace falta configurar nada nuevo:
+
+- **`FIREBASE_URL`** (obligatoria): la URL de la Realtime Database. Es la misma
+  que ya usan los scripts de sincronización del repo, así que normalmente ya está
+  en tu `.env`. No es secreta (va dentro de la app móvil).
+- **`FIREBASE_TOKEN`** (opcional): el nodo `songs` es de lectura pública (la app
+  lo lee sin login), así que para *consultar* peticiones basta con la URL. Solo
+  haría falta un token si las reglas de la base de datos bloquearan la lectura.
 
 ## Formato de `peticiones.json`
 

--- a/peticiones/README.md
+++ b/peticiones/README.md
@@ -1,0 +1,62 @@
+# Peticiones de la gente
+
+Aquí se guarda lo que la gente envía desde la app móvil y que el **MCM Panel**
+también muestra:
+
+- **Solicitudes de canciones** (`songs/solicitudes` en Firebase): peticiones de
+  canciones nuevas que la gente quiere en el cantoral.
+- **Reportes de fallitos** (`songs/fallitos` en Firebase): avisos de errores en
+  las canciones (acordes mal, letras, etc.).
+
+## Cómo se actualiza
+
+Desde el **Cantoral Admin** (el script `C. Admin Cantoral`), en el **Dashboard**
+hay un botón destacado **🙋 Consultar peticiones de la gente**, y también una
+pestaña **🙋 Peticiones** en el menú lateral.
+
+Al pulsar **Consultar y guardar**:
+
+1. El servidor lee `songs/solicitudes` y `songs/fallitos` de la Realtime
+   Database de Firebase (usa `FIREBASE_URL` y `FIREBASE_TOKEN` del `.env` de la
+   raíz del repo, igual que los scripts de sincronización).
+2. Funde lo descargado con lo que ya había en `peticiones.json` (acumula
+   histórico: las peticiones que desaparecen de Firebase porque ya se
+   resolvieron se conservan marcadas con `_inFirebase: false`).
+3. Guarda el resultado en `peticiones.json`.
+
+Para conservar el histórico en el repo, haz commit del archivo:
+
+```bash
+git add peticiones/peticiones.json
+git commit -m "chore: actualizar peticiones de la gente"
+git push
+```
+
+## Formato de `peticiones.json`
+
+```json
+{
+  "updatedAt": "2026-06-28T12:00:00+02:00",
+  "solicitudes": {
+    "<id-firebase>": {
+      "title": "…", "author": "…", "category": "…", "content": "…",
+      "userName": "…", "userLocation": "…", "platform": "web",
+      "requestedAt": "…", "status": "pendiente",
+      "_id": "<id-firebase>", "_firstSeen": "…", "_lastFetched": "…",
+      "_inFirebase": true
+    }
+  },
+  "fallitos": {
+    "<categoria>/<cancion>/<id>": {
+      "songTitle": "…", "songFilename": "…", "description": "…",
+      "categoryKey": "catFofertorio", "categoryName": "Fofertorio",
+      "userName": "…", "userLocation": "…", "platform": "web",
+      "reportedAt": "…", "status": "pending",
+      "_id": "…", "_firstSeen": "…", "_lastFetched": "…", "_inFirebase": true
+    }
+  }
+}
+```
+
+Los campos con guion bajo (`_id`, `_firstSeen`, `_lastFetched`, `_inFirebase`)
+los añade el admin para llevar el histórico; el resto vienen tal cual de la app.

--- a/peticiones/peticiones.json
+++ b/peticiones/peticiones.json
@@ -1,0 +1,5 @@
+{
+  "updatedAt": null,
+  "solicitudes": {},
+  "fallitos": {}
+}

--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -31,10 +31,13 @@ y **reportes de fallitos** (`songs/fallitos`) de la Realtime Database.
 Al pulsar **Consultar y guardar** descarga de Firebase, lo funde con el histórico
 y lo guarda en `peticiones/peticiones.json` (en la raíz del repo). Las peticiones
 que desaparecen de Firebase (ya resueltas) se conservan marcadas como archivadas.
-Haz `git commit` de ese archivo para guardar el histórico.
+Con el botón **📦 Guardar en el repo (commit)** hace `git add/commit/push` solo de
+la carpeta `peticiones/` (no toca otras ediciones `.cho` en curso).
 
-Necesita `FIREBASE_URL` y `FIREBASE_TOKEN` en el `.env` de la raíz del repo
-(los mismos que usan los scripts de sincronización). Ver `peticiones/README.md`.
+**Variables:** no hace falta añadir nada nuevo. Reutiliza el `FIREBASE_URL` del
+`.env` de la raíz que ya usan los scripts de sincronización. `FIREBASE_TOKEN` es
+**opcional**: como el nodo `songs` es de lectura pública (la app lo lee sin
+login), basta con la URL. Ver `peticiones/README.md`.
 
 ### Catálogo (📋)
 Tabla con todas las canciones del repo. Cada fila lleva badges:

--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -22,6 +22,20 @@ Contadores en vivo: cuántas canciones tienes en `/songs`, cuántas hay en el
 cantoral .docx, cuántas faltan, cuántas tienen `📝 TO DO` pendiente, cuántas
 son tuyas que no están en el cantoral.
 
+### Peticiones de la gente (🙋)
+Botón destacado en el Dashboard (**🙋 Consultar peticiones de la gente**) y
+pestaña propia en el menú. Consulta lo que la gente envía desde la app y que el
+**MCM Panel** también muestra: **solicitudes de canciones** (`songs/solicitudes`)
+y **reportes de fallitos** (`songs/fallitos`) de la Realtime Database.
+
+Al pulsar **Consultar y guardar** descarga de Firebase, lo funde con el histórico
+y lo guarda en `peticiones/peticiones.json` (en la raíz del repo). Las peticiones
+que desaparecen de Firebase (ya resueltas) se conservan marcadas como archivadas.
+Haz `git commit` de ese archivo para guardar el histórico.
+
+Necesita `FIREBASE_URL` y `FIREBASE_TOKEN` en el `.env` de la raíz del repo
+(los mismos que usan los scripts de sincronización). Ver `peticiones/README.md`.
+
 ### Catálogo (📋)
 Tabla con todas las canciones del repo. Cada fila lleva badges:
 - ✅ existe en repo + en cantoral

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -28,6 +28,9 @@ import subprocess
 import sys
 import time
 import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -43,6 +46,12 @@ SONGS_DIR = REPO_DIR / "songs"
 BACKUP_DIR = REPO_DIR / "songs-backup-edits"
 INDICE_JSON = SONGS_DIR / "indice.json"
 IGNORED_FILE = SCRIPT_DIR / "import-ignored.json"
+
+# Peticiones de la gente (solicitudes de canciones + reportes de fallitos) que la
+# app móvil guarda en Firebase. Se consultan bajo demanda y se persisten en el
+# repo para tener histórico y poder hacer commit.
+PETICIONES_DIR = REPO_DIR / "peticiones"
+PETICIONES_FILE = PETICIONES_DIR / "peticiones.json"
 
 sys.path.insert(0, str(SCRIPTS_DIR))
 import docx2chordpro as d2c  # noqa: E402
@@ -1537,6 +1546,230 @@ def api_backups_cleanup():
             shutil.rmtree(target)
             deleted.append(s["id"])
     return jsonify({"ok": True, "deleted": deleted, "kept": min(keep, len(sessions))})
+
+
+# ─────────── Peticiones de la gente (Firebase) ─────────── #
+
+_ENV_LOADED = False
+
+
+def _load_env_once() -> None:
+    """Carga el .env de la raíz del repo (FIREBASE_URL / FIREBASE_TOKEN) sin
+    depender de python-dotenv. No pisa variables ya presentes en el entorno."""
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return
+    _ENV_LOADED = True
+    env_path = REPO_DIR / ".env"
+    if not env_path.exists():
+        return
+    try:
+        for raw in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = val
+    except Exception:
+        pass
+
+
+def _fb_get_json(path: str):
+    """GET a Firebase RTDB vía REST usando solo la stdlib (urllib).
+
+    Autenticación, igual que los scripts de sync:
+      - FIREBASE_TOKEN que empieza por 'Bearer ' → cabecera Authorization
+      - token normal → query param ?auth=TOKEN
+      - una API key 'AIza…' NO sirve como token de DB → se ignora
+    """
+    _load_env_once()
+    base = (os.environ.get("FIREBASE_URL") or "").strip().rstrip("/")
+    token = (os.environ.get("FIREBASE_TOKEN") or "").strip()
+    if not base:
+        raise RuntimeError(
+            "Falta FIREBASE_URL en el archivo .env de la raíz del repo. "
+            "Añade FIREBASE_URL y FIREBASE_TOKEN para consultar las peticiones."
+        )
+    if token.startswith("AIza"):
+        token = ""  # una API key no es un token válido para la Realtime Database
+
+    url = f"{base}/{path}.json"
+    headers = {}
+    if token.startswith("Bearer "):
+        headers["Authorization"] = token
+    elif token:
+        url += "?auth=" + urllib.parse.quote(token, safe="")
+
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=25) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _flatten_fallitos(raw) -> Dict[str, dict]:
+    """Aplana la estructura (flexible) de fallitos a un dict id-compuesto → item.
+
+    La app móvil guarda los fallitos con formas distintas; replicamos la lógica
+    del MCM Panel (SongsSection.flattenFallitos):
+      A) categoría → array de items
+      B) categoría → id → item (mapa directo)
+      C) categoría → nombreCanción → id → item (estructura del ejemplo)
+
+    La clave compuesta (categoría[/canción]/id) es estable entre consultas para
+    poder fundir con el histórico sin duplicar.
+    """
+    out: Dict[str, dict] = {}
+    if not isinstance(raw, dict):
+        return out
+
+    def cat_name(cat_key: str) -> str:
+        return cat_key[3:] if cat_key.startswith("cat") else cat_key
+
+    def add(cat_key, song_key, item_id, item):
+        if not isinstance(item, dict):
+            return
+        parts = [cat_key] + ([song_key] if song_key else []) + [str(item_id)]
+        key = "/".join(parts)
+        entry = {**item, "categoryKey": cat_key, "categoryName": cat_name(cat_key)}
+        if song_key and not entry.get("songTitle") and not entry.get("title"):
+            entry["songTitle"] = song_key
+        out[key] = entry
+
+    for cat_key, level1 in raw.items():
+        if not level1:
+            continue
+        # A) categoría → array
+        if isinstance(level1, list):
+            for idx, it in enumerate(level1):
+                add(cat_key, None, idx, it)
+            continue
+        if not isinstance(level1, dict):
+            continue
+        # B) categoría → id → item (todos los hijos parecen items)
+        if all(isinstance(v, dict) and ("status" in v or "songTitle" in v or "description" in v)
+               for v in level1.values()):
+            for item_id, it in level1.items():
+                add(cat_key, None, item_id, it)
+            continue
+        # C) categoría → nombreCanción → id → item
+        for song_key, id_map in level1.items():
+            if isinstance(id_map, list):
+                for idx, it in enumerate(id_map):
+                    add(cat_key, song_key, idx, it)
+            elif isinstance(id_map, dict):
+                for item_id, it in id_map.items():
+                    add(cat_key, song_key, item_id, it)
+    return out
+
+
+def _load_peticiones_file() -> dict:
+    if PETICIONES_FILE.exists():
+        try:
+            data = json.loads(PETICIONES_FILE.read_text(encoding="utf-8"))
+            data.setdefault("solicitudes", {})
+            data.setdefault("fallitos", {})
+            return data
+        except Exception:
+            pass
+    return {"updatedAt": None, "solicitudes": {}, "fallitos": {}}
+
+
+def _save_peticiones_file(data: dict) -> None:
+    PETICIONES_DIR.mkdir(parents=True, exist_ok=True)
+    PETICIONES_FILE.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _merge_peticiones(store: Dict[str, dict], fetched: Dict[str, dict], now: str) -> int:
+    """Funde lo descargado de Firebase con el histórico guardado en el repo.
+
+    Acumula: las entradas que desaparecen de Firebase (porque ya se resolvieron
+    o borraron) se conservan marcadas con _inFirebase=False. Devuelve cuántas
+    entradas son nuevas en esta consulta.
+    """
+    for existing in store.values():
+        existing["_inFirebase"] = False
+    new_count = 0
+    for fid, item in fetched.items():
+        if fid in store:
+            merged = {**store[fid], **item}
+            merged["_firstSeen"] = store[fid].get("_firstSeen") or now
+        else:
+            merged = {**item, "_firstSeen": now}
+            new_count += 1
+        merged["_id"] = fid
+        merged["_lastFetched"] = now
+        merged["_inFirebase"] = True
+        store[fid] = merged
+    return new_count
+
+
+def _peticiones_summary(data: dict) -> dict:
+    sol = list((data.get("solicitudes") or {}).values())
+    fal = list((data.get("fallitos") or {}).values())
+    sol.sort(key=lambda x: x.get("timestamp") or 0, reverse=True)
+    fal.sort(key=lambda x: x.get("timestamp") or 0, reverse=True)
+    done_sol = {"hecho", "done", "resuelto", "rechazada", "rechazado"}
+    done_fal = {"hecho", "done", "resuelto"}
+    return {
+        "updatedAt": data.get("updatedAt"),
+        "solicitudes": sol,
+        "fallitos": fal,
+        "counts": {
+            "solicitudes_total": len(sol),
+            "solicitudes_pendientes": sum(
+                1 for x in sol if (x.get("status") or "pendiente").lower() not in done_sol
+            ),
+            "fallitos_total": len(fal),
+            "fallitos_pendientes": sum(
+                1 for x in fal if (x.get("status") or "pending").lower() not in done_fal
+            ),
+        },
+    }
+
+
+@app.route("/api/peticiones")
+def api_peticiones_get():
+    """Devuelve las peticiones ya guardadas en el repo (sin tocar Firebase)."""
+    return jsonify({"ok": True, **_peticiones_summary(_load_peticiones_file())})
+
+
+@app.route("/api/peticiones/refresh", methods=["POST"])
+def api_peticiones_refresh():
+    """Consulta Firebase (songs/solicitudes y songs/fallitos), funde con el
+    histórico local y lo persiste en peticiones/peticiones.json."""
+    data = _load_peticiones_file()
+    try:
+        sol_raw = _fb_get_json("songs/solicitudes")
+        fal_raw = _fb_get_json("songs/fallitos")
+    except urllib.error.HTTPError as e:
+        return jsonify({
+            "ok": False,
+            "error": f"Firebase respondió {e.code}. Revisa FIREBASE_TOKEN y los permisos de lectura.",
+        }), 502
+    except urllib.error.URLError as e:
+        return jsonify({"ok": False, "error": f"No pude conectar con Firebase: {e.reason}"}), 502
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+    now = datetime.now().astimezone().isoformat(timespec="seconds")
+    sol_fetched = sol_raw if isinstance(sol_raw, dict) else {}
+    fal_fetched = _flatten_fallitos(fal_raw)
+    new_sol = _merge_peticiones(data["solicitudes"], sol_fetched, now)
+    new_fal = _merge_peticiones(data["fallitos"], fal_fetched, now)
+    data["updatedAt"] = now
+    _save_peticiones_file(data)
+
+    summary = _peticiones_summary(data)
+    summary["new_solicitudes"] = new_sol
+    summary["new_fallitos"] = new_fal
+    summary["fetched_solicitudes"] = len(sol_fetched)
+    summary["fetched_fallitos"] = len(fal_fetched)
+    summary["saved_to"] = str(PETICIONES_FILE.relative_to(REPO_DIR))
+    return jsonify({"ok": True, **summary})
 
 
 @app.route("/api/health")

--- a/scripts/admin/server.py
+++ b/scripts/admin/server.py
@@ -1712,8 +1712,11 @@ def _peticiones_summary(data: dict) -> dict:
     fal = list((data.get("fallitos") or {}).values())
     sol.sort(key=lambda x: x.get("timestamp") or 0, reverse=True)
     fal.sort(key=lambda x: x.get("timestamp") or 0, reverse=True)
-    done_sol = {"hecho", "done", "resuelto", "rechazada", "rechazado"}
-    done_fal = {"hecho", "done", "resuelto"}
+    # Estados terminales (igual que el MCM Panel):
+    #   solicitudes → pendiente | en progreso | hecho | cancelado
+    #   fallitos    → pending | in progress | done
+    done_sol = {"hecho", "done", "cancelado", "cancelled", "resuelto"}
+    done_fal = {"done", "hecho", "resuelto"}
     return {
         "updatedAt": data.get("updatedAt"),
         "solicitudes": sol,
@@ -1770,6 +1773,49 @@ def api_peticiones_refresh():
     summary["fetched_fallitos"] = len(fal_fetched)
     summary["saved_to"] = str(PETICIONES_FILE.relative_to(REPO_DIR))
     return jsonify({"ok": True, **summary})
+
+
+@app.route("/api/peticiones/commit", methods=["POST"])
+def api_peticiones_commit():
+    """Hace git add/commit/push SOLO de la carpeta peticiones/ (no toca otras
+    ediciones .cho que tengas en curso)."""
+    data = _load_peticiones_file()
+    counts = _peticiones_summary(data)["counts"]
+    message = (
+        f"chore: actualizar peticiones de la gente "
+        f"({counts['solicitudes_total']} solicitudes, {counts['fallitos_total']} fallitos)"
+    )
+    steps = []
+
+    def step(name, proc):
+        steps.append({
+            "step": name, "returncode": proc.returncode,
+            "stdout": proc.stdout, "stderr": proc.stderr,
+        })
+        return proc.returncode == 0
+
+    try:
+        rel = str(PETICIONES_DIR.relative_to(REPO_DIR))
+        if not step("add", _run_git(["add", rel])):
+            return jsonify({"ok": False, "steps": steps, "error": "Fallo en git add"}), 500
+        commit = _run_git(["commit", "-m", message])
+        step("commit", commit)
+        nothing = "nothing to commit" in (commit.stdout + commit.stderr)
+        if commit.returncode != 0 and not nothing:
+            return jsonify({"ok": False, "steps": steps, "error": "Fallo en git commit"}), 500
+        if nothing:
+            return jsonify({"ok": True, "nothing": True, "steps": steps,
+                            "message": "No hay cambios nuevos que guardar (ya estaba todo commiteado)."})
+        branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+        has_upstream = _run_git(["rev-parse", "--abbrev-ref", "@{u}"]).returncode == 0
+        push_args = ["push"] if has_upstream else ["push", "-u", "origin", branch]
+        if not step("push", _run_git(push_args, timeout=60)):
+            return jsonify({"ok": False, "steps": steps,
+                            "error": "Commit hecho, pero falló el push (¿conexión?)."}), 500
+        return jsonify({"ok": True, "branch": branch, "steps": steps,
+                        "message": f"Guardado y subido a la rama {branch}."})
+    except Exception as e:
+        return jsonify({"ok": False, "steps": steps, "error": str(e)}), 500
 
 
 @app.route("/api/health")

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -114,7 +114,7 @@ function app() {
 
     // Peticiones de la gente (solicitudes de canciones + fallitos desde Firebase)
     peticiones: {
-      loading: false, refreshing: false, loaded: false,
+      loading: false, refreshing: false, committing: false, loaded: false,
       updatedAt: null,
       solicitudes: [], fallitos: [],
       counts: { solicitudes_total: 0, solicitudes_pendientes: 0,
@@ -1961,6 +1961,21 @@ function app() {
         this.peticiones.error = 'No pude consultar Firebase: ' + e.message;
       } finally {
         this.peticiones.refreshing = false;
+      }
+    },
+    async commitPeticiones() {
+      this.peticiones.committing = true;
+      this.peticiones.error = null;
+      try {
+        const r = await fetch('/api/peticiones/commit', { method: 'POST' });
+        const d = await r.json();
+        if (!d.ok) throw new Error(d.error || ('HTTP ' + r.status));
+        this.peticiones.message = '✓ ' + (d.message || 'Guardado en el repo.');
+        this.loadGitStatus(true);
+      } catch (e) {
+        this.peticiones.error = 'No pude guardar en el repo: ' + e.message;
+      } finally {
+        this.peticiones.committing = false;
       }
     },
     fmtFecha(x) {

--- a/scripts/admin/static/app.js
+++ b/scripts/admin/static/app.js
@@ -112,6 +112,16 @@ function app() {
     // Backups
     backups: { sessions: [], total_size_bytes: 0, loading: false, keepLast: 5 },
 
+    // Peticiones de la gente (solicitudes de canciones + fallitos desde Firebase)
+    peticiones: {
+      loading: false, refreshing: false, loaded: false,
+      updatedAt: null,
+      solicitudes: [], fallitos: [],
+      counts: { solicitudes_total: 0, solicitudes_pendientes: 0,
+                fallitos_total: 0, fallitos_pendientes: 0 },
+      message: '', error: null,
+    },
+
     // Estado de git (indicador en la barra lateral)
     git: { branch: '', ahead: 0, behind: 0, dirty: false, changedCount: 0,
            changedFiles: [], hasUpstream: true, loading: false, error: null },
@@ -1905,6 +1915,60 @@ function app() {
         alert('Error: ' + e.message);
       }
     },
+    // ─────────── Peticiones de la gente ───────────
+    goPeticiones() {
+      this.view = 'peticiones';
+      if (!this.peticiones.loaded) this.loadPeticiones();
+    },
+    _applyPeticiones(d) {
+      this.peticiones.updatedAt = d.updatedAt;
+      this.peticiones.solicitudes = d.solicitudes || [];
+      this.peticiones.fallitos = d.fallitos || [];
+      if (d.counts) this.peticiones.counts = d.counts;
+    },
+    async loadPeticiones() {
+      this.peticiones.loading = true; this.peticiones.error = null;
+      try {
+        const r = await fetch('/api/peticiones');
+        const d = await r.json();
+        if (!d.ok) throw new Error(d.error || ('HTTP ' + r.status));
+        this._applyPeticiones(d);
+        this.peticiones.loaded = true;
+      } catch (e) {
+        this.peticiones.error = 'No pude cargar las peticiones guardadas: ' + e.message;
+      } finally {
+        this.peticiones.loading = false;
+      }
+    },
+    async refreshPeticiones() {
+      this.peticiones.refreshing = true;
+      this.peticiones.error = null;
+      this.peticiones.message = '';
+      try {
+        const r = await fetch('/api/peticiones/refresh', { method: 'POST' });
+        const d = await r.json();
+        if (!d.ok) throw new Error(d.error || ('HTTP ' + r.status));
+        this._applyPeticiones(d);
+        this.peticiones.loaded = true;
+        const ns = d.new_solicitudes || 0, nf = d.new_fallitos || 0;
+        let novedad = (ns || nf)
+          ? `${ns} solicitud(es) y ${nf} fallito(s) nuevos`
+          : 'sin novedades';
+        this.peticiones.message =
+          `✓ Hecho · ${d.counts.solicitudes_total} solicitudes y ${d.counts.fallitos_total} fallitos guardados (${novedad}). ` +
+          `Guardado en ${d.saved_to || 'peticiones/peticiones.json'} — haz git commit para conservarlo.`;
+      } catch (e) {
+        this.peticiones.error = 'No pude consultar Firebase: ' + e.message;
+      } finally {
+        this.peticiones.refreshing = false;
+      }
+    },
+    fmtFecha(x) {
+      const v = x && (x.requestedAt || x.reportedAt || x._lastFetched);
+      if (!v) return '—';
+      try { return new Date(v).toLocaleString('es-ES'); } catch (e) { return v; }
+    },
+
     formatBytes(bytes) {
       if (bytes < 1024) return bytes + ' B';
       if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -1008,9 +1008,15 @@
        <code>peticiones/peticiones.json</code>. Haz <code>git commit</code> para conservar el histórico.</p>
 
     <div class="filter-bar" style="justify-content: flex-start;">
-      <button class="btn primary" @click="refreshPeticiones()" :disabled="peticiones.refreshing">
+      <button class="btn primary" @click="refreshPeticiones()" :disabled="peticiones.refreshing || peticiones.committing">
         <span x-show="!peticiones.refreshing">🔄 Consultar y guardar</span>
         <span x-show="peticiones.refreshing">⏳ Consultando Firebase…</span>
+      </button>
+      <button class="btn" @click="commitPeticiones()"
+              :disabled="peticiones.committing || peticiones.refreshing"
+              title="Hace git add/commit/push solo de la carpeta peticiones/">
+        <span x-show="!peticiones.committing">📦 Guardar en el repo (commit)</span>
+        <span x-show="peticiones.committing">⏳ Guardando en git…</span>
       </button>
       <span class="muted" style="font-size:12px" x-show="peticiones.updatedAt">
         Última consulta: <span x-text="fmtFecha({ _lastFetched: peticiones.updatedAt })"></span>

--- a/scripts/admin/static/index.html
+++ b/scripts/admin/static/index.html
@@ -28,6 +28,7 @@
     <a :class="{active: view === 'latex'}" @click.prevent="view = 'latex'; loadLatex()" href="#">📐 Importar de LaTeX</a>
     <a :class="{active: view === 'doce'}" @click.prevent="view = 'doce'; loadDoce()" href="#">🎸 Importar de doceacordes</a>
     <a :class="{active: view === 'reorder'}" @click.prevent="view = 'reorder'" href="#">🔀 Reordenar</a>
+    <a :class="{active: view === 'peticiones'}" @click.prevent="goPeticiones()" href="#">🙋 Peticiones</a>
     <a :class="{active: view === 'backups'}" @click.prevent="view = 'backups'; loadBackups()" href="#">🗂 Backups</a>
   </nav>
 
@@ -76,6 +77,19 @@
   <!-- DASHBOARD -->
   <section x-show="view === 'dashboard' && data" x-cloak>
     <h1>📊 Dashboard</h1>
+
+    <div class="peticiones-banner">
+      <div class="peticiones-banner-text">
+        <h3>🙋 Peticiones de la gente</h3>
+        <p class="muted">Consulta las solicitudes de canciones y los reportes de fallitos que la
+           gente envía desde la app. Se descargan de Firebase y se guardan en el repo.</p>
+      </div>
+      <button class="btn primary big" @click="view = 'peticiones'; refreshPeticiones()"
+              :disabled="peticiones.refreshing">
+        <span x-show="!peticiones.refreshing">🙋 Consultar peticiones de la gente</span>
+        <span x-show="peticiones.refreshing">⏳ Consultando…</span>
+      </button>
+    </div>
 
     <div class="stats-group">
       <h3 class="stats-group-title">📚 Catálogo</h3>
@@ -985,6 +999,109 @@
   </section>
 
   <!-- BACKUPS -->
+  <!-- PETICIONES DE LA GENTE -->
+  <section x-show="view === 'peticiones'" x-cloak>
+    <h1>🙋 Peticiones de la gente</h1>
+    <p class="muted">Solicitudes de canciones y reportes de fallitos que la gente manda desde la app
+       (lo que el MCM Panel muestra). Al consultar, se descargan de Firebase
+       (<code>songs/solicitudes</code> y <code>songs/fallitos</code>) y se guardan en
+       <code>peticiones/peticiones.json</code>. Haz <code>git commit</code> para conservar el histórico.</p>
+
+    <div class="filter-bar" style="justify-content: flex-start;">
+      <button class="btn primary" @click="refreshPeticiones()" :disabled="peticiones.refreshing">
+        <span x-show="!peticiones.refreshing">🔄 Consultar y guardar</span>
+        <span x-show="peticiones.refreshing">⏳ Consultando Firebase…</span>
+      </button>
+      <span class="muted" style="font-size:12px" x-show="peticiones.updatedAt">
+        Última consulta: <span x-text="fmtFecha({ _lastFetched: peticiones.updatedAt })"></span>
+      </span>
+      <span class="muted" style="font-size:12px" x-show="!peticiones.updatedAt && !peticiones.loading">
+        Aún no se ha consultado nunca.
+      </span>
+    </div>
+
+    <div class="peticiones-msg ok" x-show="peticiones.message" x-cloak x-text="peticiones.message"></div>
+    <div class="peticiones-msg err" x-show="peticiones.error" x-cloak
+         x-text="'⚠️ ' + peticiones.error"></div>
+
+    <div x-show="peticiones.loading" class="muted" style="padding:20px">Cargando…</div>
+
+    <!-- Solicitudes de canciones -->
+    <div class="stats-group">
+      <h3 class="stats-group-title">
+        🎵 Solicitudes de canciones
+        <span class="badge-count" x-text="peticiones.counts.solicitudes_pendientes + ' pendientes · ' + peticiones.counts.solicitudes_total + ' total'"></span>
+      </h3>
+      <p class="muted" x-show="peticiones.solicitudes.length === 0 && !peticiones.loading">
+        No hay solicitudes guardadas todavía.</p>
+      <table class="songs" x-show="peticiones.solicitudes.length > 0">
+        <thead>
+          <tr><th>Título</th><th>Autor</th><th>Categoría</th><th>Quién</th><th>Fecha</th><th>Estado</th></tr>
+        </thead>
+        <tbody>
+          <template x-for="s in peticiones.solicitudes" :key="s._id">
+            <tr :class="{ 'row-archived': s._inFirebase === false }">
+              <td>
+                <strong x-text="s.title || '(sin título)'"></strong>
+                <div class="muted" style="font-size:11px;white-space:pre-wrap;max-width:420px"
+                     x-show="s.content" x-text="s.content"></div>
+              </td>
+              <td x-text="s.author || '—'"></td>
+              <td x-text="s.category || '—'"></td>
+              <td>
+                <span x-text="s.userName || 'Anónimo'"></span>
+                <span class="muted" style="font-size:11px" x-show="s.userLocation" x-text="' · ' + s.userLocation"></span>
+                <span class="muted" style="font-size:11px" x-show="s.platform" x-text="' · ' + s.platform"></span>
+              </td>
+              <td style="white-space:nowrap" x-text="fmtFecha(s)"></td>
+              <td>
+                <span class="status-pill" x-text="s.status || 'pendiente'"></span>
+                <span class="muted" style="font-size:11px" x-show="s._inFirebase === false" title="Ya no está en Firebase (resuelta o borrada)">· archivada</span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Reportes de fallitos -->
+    <div class="stats-group">
+      <h3 class="stats-group-title">
+        🐛 Reportes de fallitos
+        <span class="badge-count" x-text="peticiones.counts.fallitos_pendientes + ' pendientes · ' + peticiones.counts.fallitos_total + ' total'"></span>
+      </h3>
+      <p class="muted" x-show="peticiones.fallitos.length === 0 && !peticiones.loading">
+        No hay fallitos guardados todavía.</p>
+      <table class="songs" x-show="peticiones.fallitos.length > 0">
+        <thead>
+          <tr><th>Canción</th><th>Descripción</th><th>Categoría</th><th>Quién</th><th>Fecha</th><th>Estado</th></tr>
+        </thead>
+        <tbody>
+          <template x-for="f in peticiones.fallitos" :key="f._id">
+            <tr :class="{ 'row-archived': f._inFirebase === false }">
+              <td>
+                <strong x-text="f.songTitle || '(sin título)'"></strong>
+                <div class="muted" style="font-size:11px;font-family:monospace" x-show="f.songFilename" x-text="f.songFilename"></div>
+              </td>
+              <td style="white-space:pre-wrap;max-width:420px" x-text="f.description || '—'"></td>
+              <td x-text="f.categoryName || f.categoryKey || '—'"></td>
+              <td>
+                <span x-text="f.userName || 'Anónimo'"></span>
+                <span class="muted" style="font-size:11px" x-show="f.userLocation" x-text="' · ' + f.userLocation"></span>
+                <span class="muted" style="font-size:11px" x-show="f.platform" x-text="' · ' + f.platform"></span>
+              </td>
+              <td style="white-space:nowrap" x-text="fmtFecha(f)"></td>
+              <td>
+                <span class="status-pill" x-text="f.status || 'pending'"></span>
+                <span class="muted" style="font-size:11px" x-show="f._inFirebase === false" title="Ya no está en Firebase (resuelto o borrado)">· archivado</span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
   <section x-show="view === 'backups'" x-cloak>
     <h1>🗂 Gestión de backups</h1>
     <p class="muted">Cada vez que guardas o borras una canción se crea una copia en

--- a/scripts/admin/static/style.css
+++ b/scripts/admin/static/style.css
@@ -784,3 +784,20 @@ body.adding .ed-char:hover { background: rgba(37, 99, 235, 0.15); cursor: pointe
 .preview-render .pv-seg { display: inline-block; vertical-align: top; position: relative; }
 .preview-render .pv-chords { display: block; color: var(--accent); font-weight: 700; font-family: 'SF Mono', monospace; font-size: 0.85em; height: 1.2em; }
 .preview-render .pv-lyr { display: block; white-space: pre; font-size: 1em; }
+
+/* ─────────── Peticiones de la gente ─────────── */
+.peticiones-banner {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  flex-wrap: wrap; margin: 0 0 22px; padding: 18px 22px;
+  background: linear-gradient(135deg, rgba(37,99,235,0.10), rgba(37,99,235,0.03));
+  border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px;
+}
+.peticiones-banner-text h3 { margin: 0 0 4px; font-size: 16px; }
+.peticiones-banner-text p { margin: 0; max-width: 560px; font-size: 13px; }
+.btn.big { font-size: 15px; padding: 12px 20px; font-weight: 600; white-space: nowrap; }
+.peticiones-msg { margin: 12px 0; padding: 10px 14px; border-radius: 6px; font-size: 13px; }
+.peticiones-msg.ok { background: rgba(22,163,74,0.12); color: var(--ok); border: 1px solid rgba(22,163,74,0.25); }
+.peticiones-msg.err { background: rgba(220,38,38,0.12); color: var(--danger); border: 1px solid rgba(220,38,38,0.25); }
+.badge-count { font-size: 11px; font-weight: 600; color: var(--fg-3); margin-left: 8px; }
+.status-pill { background: var(--bg-3); color: var(--fg-2); border: 1px solid var(--border); }
+table.songs tr.row-archived td { opacity: 0.55; }


### PR DESCRIPTION
Añade al **Cantoral Admin** (script C) una forma de consultar lo que la gente
envía desde la app y que el **MCM Panel** también muestra: **solicitudes de
canciones** (`songs/solicitudes`) y **reportes de fallitos** (`songs/fallitos`).

## Qué incluye

**Dashboard**
- Banner/botón destacado **🙋 Consultar peticiones de la gente**.

**Nueva pestaña 🙋 Peticiones**
- Tabla de **solicitudes de canciones** y tabla de **fallitos de canciones**, con
  contadores de pendientes/total, fecha, quién lo envió y estado.
- Botón **🔄 Consultar y guardar**: descarga de Firebase, funde con el histórico
  y escribe `peticiones/peticiones.json`.
- Botón **📦 Guardar en el repo (commit)**: hace `git add/commit/push` acotado a
  la carpeta `peticiones/` (no toca otras ediciones `.cho` en curso).

**Backend (`scripts/admin/server.py`)**
- Lee la Realtime Database por REST con la stdlib (sin dependencias nuevas).
- Aplana la estructura flexible de fallitos replicando la lógica del MCM Panel
  (`flattenFallitos`: categoría→array, categoría→id→item y categoría→canción→id→item).
- Funde con el histórico (acumula): las peticiones que desaparecen de Firebase se
  conservan marcadas como archivadas (`_inFirebase: false`).
- Endpoints: `GET /api/peticiones`, `POST /api/peticiones/refresh`,
  `POST /api/peticiones/commit`.

**Repo**
- Carpeta versionada `peticiones/` con `README.md` y `peticiones.json` inicial.

## Variables de Firebase
No hace falta configurar nada nuevo: reutiliza el `FIREBASE_URL` del `.env` que
ya usan los scripts de sincronización. `FIREBASE_TOKEN` es **opcional** porque el
nodo `songs` es de lectura pública (la app lo lee sin login).

## Notas
- Alcance: solo canciones (`songs/solicitudes` y `songs/fallitos`). El feedback
  general de la app (`app/feedback`) queda fuera a propósito.
- Validado: el aplanado/fusión/contadores con los ejemplos reales del MCM Panel;
  compilación de `server.py`, sintaxis de `app.js` y balanceo del HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)